### PR TITLE
Use flow update times

### DIFF
--- a/aw/AmericanWhitewater.xcdatamodeld/AmericanWhitewater.xcdatamodel/contents
+++ b/aw/AmericanWhitewater.xcdatamodeld/AmericanWhitewater.xcdatamodel/contents
@@ -36,6 +36,7 @@
         <attribute name="favorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="gageId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="gageMetric" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="gageUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="id" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="lastGageReading" attributeType="String" syncable="YES"/>
         <attribute name="length" optional="YES" attributeType="String" syncable="YES"/>
@@ -62,7 +63,7 @@
     </entity>
     <elements>
         <element name="Article" positionX="-72" positionY="-9" width="128" height="180"/>
-        <element name="Reach" positionX="-299" positionY="-9" width="128" height="540"/>
+        <element name="Reach" positionX="-299" positionY="-9" width="128" height="553"/>
         <element name="Rapid" positionX="-72" positionY="396" width="128" height="148"/>
     </elements>
 </model>

--- a/aw/Extensions/Reach.swift
+++ b/aw/Extensions/Reach.swift
@@ -39,7 +39,12 @@ extension Reach {
     }
 
     var updatedString: String? {
-        guard let date = detailUpdated else { return nil }
+        guard let date = gageUpdated else {
+            if detailUpdated != nil {
+                return "No flow information"
+            }
+            return nil
+        }
         let dateFormat = DateFormatter()
         dateFormat.dateStyle = .medium
         dateFormat.doesRelativeDateFormatting = true

--- a/aw/Helpers/AWApiHelper.swift
+++ b/aw/Helpers/AWApiHelper.swift
@@ -104,6 +104,10 @@ struct AWApiHelper {
         reach.gageId = Int32(newReach.gageId ?? 0)
         reach.gageMetric = Int16(newReach.gageMetric ?? 0)
 
+        if let updatedSecondsString = newReach.lastGageUpdated, let updatedSecondsAgo = Int(updatedSecondsString) {
+            reach.gageUpdated = Date().addingTimeInterval(TimeInterval(-updatedSecondsAgo))
+        }
+
         if let distance = newReach.distanceFrom(
             location: CLLocation(
                 latitude: DefaultsManager.latitude,

--- a/aw/Models/AWApi/AWReach.swift
+++ b/aw/Models/AWApi/AWReach.swift
@@ -11,6 +11,7 @@ struct AWReach: Codable {
     let putInLat: String?
     let putInLon: String?
     let lastGageReading: String?
+    let lastGageUpdated: String?
     let section: String
     let unit: String?
     let takeOutLat: String?
@@ -30,6 +31,7 @@ struct AWReach: Codable {
         case putInLat = "plat"
         case putInLon = "plon"
         case lastGageReading = "last_gauge_reading"
+        case lastGageUpdated = "last_gauge_updated"
         case takeOutLat = "tlat"
         case takeOutLon = "tlon"
         case gageId = "gauge_id"


### PR DESCRIPTION
Run details now shows when the flow was last updated, or 'no flow information' rather than when the details were updated.