### PR TITLE
Show cursor when searching

### DIFF
--- a/aw/AppDelegate.swift
+++ b/aw/AppDelegate.swift
@@ -73,6 +73,7 @@ extension AppDelegate {
         UINavigationBar.appearance().tintColor = UIColor(named: "white")
         UINavigationBar.appearance().titleTextAttributes = [
             NSAttributedStringKey.foregroundColor: UIColor(named: "white")]
+        UISearchBar.appearance().tintColor = UIColor.black
 
         UITabBar.appearance().tintColor = UIColor(named: "primary")
     }


### PR DESCRIPTION
The cursor in the searchbar was not displaying as it was inheriting a white tint color.