### PR TITLE
Hide keyboard after hitting search in region filter

### DIFF
--- a/aw/Base.lproj/Main.storyboard
+++ b/aw/Base.lproj/Main.storyboard
@@ -1688,8 +1688,8 @@ plan for your next run!</string>
         </namedColor>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="vCc-Lg-GX5"/>
+        <segue reference="35b-Ee-eOR"/>
         <segue reference="HLz-3E-X9y"/>
-        <segue reference="YkS-Jf-Fvi"/>
+        <segue reference="nNq-n1-7H9"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/aw/ViewControllers/Reaches/Filters/FilterRegionViewController.swift
+++ b/aw/ViewControllers/Reaches/Filters/FilterRegionViewController.swift
@@ -23,6 +23,7 @@ extension FilterRegionViewController {
         tableView.delegate = self
         tableView.dataSource = self
         searchBar.delegate = self
+        searchBar.returnKeyType = .done
 
         selectedRegions = DefaultsManager.regionsFilter
 

--- a/aw/ViewControllers/Reaches/Filters/FilterRegionViewController.swift
+++ b/aw/ViewControllers/Reaches/Filters/FilterRegionViewController.swift
@@ -57,6 +57,10 @@ extension FilterRegionViewController: UISearchBarDelegate {
         }
         self.tableView.reloadData()
     }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
 }
 
 // MARK: - UITableViewDelegate, UITableViewDataSource

--- a/aw/ViewControllers/Reaches/RunListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/RunListTableViewController.swift
@@ -117,6 +117,7 @@ extension RunListTableViewController {
     func setupSearchControl() {
         searchController.searchResultsUpdater = self
         searchController.searchBar.delegate = self
+        searchController.searchBar.returnKeyType = .done
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.placeholder = searchText()
         searchController.hidesNavigationBarDuringPresentation = false


### PR DESCRIPTION
Just as it says on the tin. After you hit search on the keyboard in the region filters, then the keyboard hides.