### PR TITLE
Set default tab to Run list

### DIFF
--- a/aw/ViewControllers/TabViewController.swift
+++ b/aw/ViewControllers/TabViewController.swift
@@ -6,6 +6,7 @@ class TabViewController: UITabBarController, MOCViewControllerType {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.selectedIndex = 1
 
         self.delegate = self
 


### PR DESCRIPTION
When the tab view initially loads it defaults to run list.

Should it default to the favorites tab once a user has selected some?