### PR TITLE
Hide see gage info

### DIFF
--- a/aw/ViewControllers/Reaches/Detail/RunDetailTableViewController.swift
+++ b/aw/ViewControllers/Reaches/Detail/RunDetailTableViewController.swift
@@ -115,6 +115,11 @@ class RunDetailTableViewController: UITableViewController {
             return expandDescription ? UITableViewAutomaticDimension : 168
         case IndexPath(row: 0, section: 2):
             return 77
+        case IndexPath(row: 0, section: 3): // Gage info
+            if reach?.gageId != 0 {
+                return 44
+            }
+            return 0
         default:
             return 44
         }


### PR DESCRIPTION
Hide 'See gage info' button on run details if a run does not have an associated gage.