### PR TITLE
Show favorites as the default tab

### DIFF
--- a/aw/ViewControllers/TabViewController.swift
+++ b/aw/ViewControllers/TabViewController.swift
@@ -17,6 +17,14 @@ class TabViewController: UITabBarController, MOCViewControllerType {
                 destinationVC.managedObjectContext = managedObjectContext
             }
         }
+
+        if let context = managedObjectContext {
+            let request = NSFetchRequest<Reach>(entityName: "Reach")
+            request.predicate = NSPredicate(format: "favorite = TRUE" )
+            if let count = try? context.count(for: request), count > 0 {
+                self.selectedIndex = 2
+            }
+        }
     }
 }
 

--- a/aw/ViewControllers/TabViewController.swift
+++ b/aw/ViewControllers/TabViewController.swift
@@ -6,6 +6,7 @@ class TabViewController: UITabBarController, MOCViewControllerType {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.selectedIndex = 1
 
         self.delegate = self
 


### PR DESCRIPTION
If the user doesn't have any favorites set, then we should show the run list as default.