### PR TITLE
Show map icon as designed rather than as a template

### DIFF
--- a/aw/Assets.xcassets/icon_map.imageset/Contents.json
+++ b/aw/Assets.xcassets/icon_map.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }


### PR DESCRIPTION
The map icon in the tab bar wasn't getting displayed correctly due to template tinting. 