### PR TITLE
Use reach altname if available

### DIFF
--- a/aw/Helpers/AWApiHelper.swift
+++ b/aw/Helpers/AWApiHelper.swift
@@ -88,7 +88,14 @@ struct AWApiHelper {
             reach.state = region.title
         }
 
-        reach.section = newReach.section
+        if let altName = newReach.altName, !altName.isEmpty {
+            reach.section = altName
+        } else {
+            reach.section = newReach.section
+        }
+
+        //reach.section = newReach.section
+        //reach.section = newReach.altName != "" ? newReach.altName : newReach.section
         reach.putInLat = newReach.putInLat
         reach.putInLon = newReach.putInLon
         reach.name = newReach.name

--- a/aw/Models/AWApi/AWReach.swift
+++ b/aw/Models/AWApi/AWReach.swift
@@ -8,6 +8,7 @@ struct AWReach: Codable {
     //swiftlint:disable:next identifier_name
     let id: Int
     let name: String
+    let altName: String?
     let putInLat: String?
     let putInLon: String?
     let lastGageReading: String?
@@ -27,6 +28,7 @@ struct AWReach: Codable {
         //swiftlint:disable:next identifier_name
         case id, name, section, unit, state, delta, rc
         case difficulty = "class"
+        case altName = "altname"
         case condition = "cond"
         case putInLat = "plat"
         case putInLon = "plon"


### PR DESCRIPTION
Use the altname (common name) for a reach if available otherwise use the section name.