### PR TITLE
Sort order and Map Zoom

### DIFF
--- a/aw/AmericanWhitewater.xcdatamodeld/AmericanWhitewater.xcdatamodel/contents
+++ b/aw/AmericanWhitewater.xcdatamodeld/AmericanWhitewater.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14133" systemVersion="17E202" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14133" systemVersion="17F77" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Article" representedClassName="Article" syncable="YES" codeGenerationType="class">
         <attribute name="abstract" attributeType="String" syncable="YES"/>
         <attribute name="abstractPhoto" optional="YES" attributeType="String" syncable="YES"/>
@@ -49,6 +49,7 @@
         <attribute name="rc" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="section" attributeType="String" syncable="YES"/>
         <attribute name="shuttleDetails" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="sortName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="state" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="takeOutLat" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="takeOutLon" optional="YES" attributeType="String" syncable="YES"/>
@@ -63,7 +64,7 @@
     </entity>
     <elements>
         <element name="Article" positionX="-72" positionY="-9" width="128" height="180"/>
-        <element name="Reach" positionX="-299" positionY="-9" width="128" height="553"/>
         <element name="Rapid" positionX="-72" positionY="396" width="128" height="148"/>
+        <element name="Reach" positionX="-299" positionY="-9" width="128" height="570"/>
     </elements>
 </model>

--- a/aw/Helpers/AWApiHelper.swift
+++ b/aw/Helpers/AWApiHelper.swift
@@ -93,6 +93,7 @@ struct AWApiHelper {
         } else {
             reach.section = newReach.section
         }
+        reach.sortName = newReach.section
 
         //reach.section = newReach.section
         //reach.section = newReach.altName != "" ? newReach.altName : newReach.section

--- a/aw/ViewControllers/Reaches/Detail/ReachDetailMapViewController.swift
+++ b/aw/ViewControllers/Reaches/Detail/ReachDetailMapViewController.swift
@@ -50,6 +50,7 @@ extension ReachDetailMapViewController {
 
     func setupMap() {
         mapView.showsUserLocation = true
+        mapView.layoutMargins = UIEdgeInsetsMake(0, 0, 40, 0)
         setupAnnotations()
     }
 

--- a/aw/ViewControllers/Reaches/RunListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/RunListTableViewController.swift
@@ -207,10 +207,13 @@ extension RunListTableViewController {
         if DefaultsManager.distanceFilter > 0 {
             self.fetchedResultsController?.fetchRequest.sortDescriptors = [
                 NSSortDescriptor(key: "distance", ascending: true),
-                NSSortDescriptor(key: "name", ascending: true)]
+                NSSortDescriptor(key: "name", ascending: true)
+            ]
         } else {
             self.fetchedResultsController?.fetchRequest.sortDescriptors = [
-                NSSortDescriptor(key: "name", ascending: true)]
+                NSSortDescriptor(key: "name", ascending: true),
+                NSSortDescriptor(key: "sortName", ascending: true)
+            ]
         }
 
         self.fetchedResultsController?.fetchRequest.predicate = NSCompoundPredicate(


### PR DESCRIPTION
Change the sort order on the runs list to be by name, then by section (from the server). This ensures that reaches on a particular river show up in order. 

Also set the map zoom on the run detail page to not show points of interest under the legend. 