### PR TITLE
Batch update all distances to reaches

### DIFF
--- a/aw.xcodeproj/project.pbxproj
+++ b/aw.xcodeproj/project.pbxproj
@@ -46,13 +46,13 @@
 		385E59D52063073900A68EC9 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 385E59D42063073900A68EC9 /* MapKit.framework */; };
 		3864857D206BC355009B360F /* OnboardLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3864857C206BC355009B360F /* OnboardLocationViewController.swift */; };
 		387C52C220D55CD90056D4AB /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 387C52C120D55CD90056D4AB /* UIView.swift */; };
+		3886FFA720EAB8EE0092C810 /* AmericanWhitewater.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8EB2066E6EC00B5BA29 /* AmericanWhitewater.xcdatamodeld */; };
 		38A4AB1A20BF517100543A33 /* ReachDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A4AB1920BF517100543A33 /* ReachDetailViewController.swift */; };
 		38A6C8D92066759A00B5BA29 /* RunListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8D82066759A00B5BA29 /* RunListTableViewController.swift */; };
 		38A6C8DB206677EC00B5BA29 /* RunListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8DA206677EC00B5BA29 /* RunListTableViewCell.swift */; };
 		38A6C8E3206687EC00B5BA29 /* MOCViewControllerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8E2206687EC00B5BA29 /* MOCViewControllerType.swift */; };
 		38A6C8E82066882300B5BA29 /* NSPersistentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8E72066882300B5BA29 /* NSPersistentContainer.swift */; };
 		38A6C8EA2066884800B5BA29 /* NSManagedObjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8E92066884800B5BA29 /* NSManagedObjectContext.swift */; };
-		38A6C8ED2066E6EC00B5BA29 /* AmericanWhitewater.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8EB2066E6EC00B5BA29 /* AmericanWhitewater.xcdatamodeld */; };
 		38A6C8EF2067074700B5BA29 /* Reach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8EE2067074700B5BA29 /* Reach.swift */; };
 		38A6C8F120670AEF00B5BA29 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8F020670AEF00B5BA29 /* MapViewController.swift */; };
 		38A6C8F42067189300B5BA29 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A6C8F32067189300B5BA29 /* SplashViewController.swift */; };
@@ -585,7 +585,6 @@
 				38EBDF0B20B4F8AA007F7B15 /* CheckBoxButton.swift in Sources */,
 				38BE74A6206827A200DE555D /* DifficultyHelper.swift in Sources */,
 				385E59C22063047B00A68EC9 /* AppDelegate.swift in Sources */,
-				38A6C8ED2066E6EC00B5BA29 /* AmericanWhitewater.xcdatamodeld in Sources */,
 				3836C4A12071113D00490999 /* MoreTableViewController.swift in Sources */,
 				3836C48E20708E7900490999 /* Article.swift in Sources */,
 				38A6C8E3206687EC00B5BA29 /* MOCViewControllerType.swift in Sources */,
@@ -608,6 +607,7 @@
 				3836C4992071088E00490999 /* Condition.swift in Sources */,
 				38A98F8F2067F0B4009853E1 /* FilterExtendedNavBarView.swift in Sources */,
 				38A98F732067ED2E009853E1 /* AboutAWMissionViewController.swift in Sources */,
+				3886FFA720EAB8EE0092C810 /* AmericanWhitewater.xcdatamodeld in Sources */,
 				38A6C8DB206677EC00B5BA29 /* RunListTableViewCell.swift in Sources */,
 				38A98F7B2067ED4D009853E1 /* AboutAWFundingViewController.swift in Sources */,
 				38A6C8E82066882300B5BA29 /* NSPersistentContainer.swift in Sources */,

--- a/aw/Helpers/AWApiHelper.swift
+++ b/aw/Helpers/AWApiHelper.swift
@@ -390,6 +390,11 @@ struct AWApiHelper {
     }
 
     static func updateDistances(viewContext: NSManagedObjectContext) {
+        // At times it may take a noticable amount of time to calculate the distance
+        // from the current location to each reach. This causes slow shuffling of rows
+        // on the run list screen. To avoid this we set all reaches to a very large
+        // distance, causing everything to dissapear, then update the indivudual reaches.
+        //
         // batch update all distances quickly
         let bulkGroup = DispatchGroup()
         let bulkContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)


### PR DESCRIPTION
When calculating distances from a new location, it batch updates all distances to a massive distance to hide them from a distance filter, then it updates each individual distance.