### PR TITLE
Add auto refresh option

### DIFF
--- a/aw/AppDelegate.swift
+++ b/aw/AppDelegate.swift
@@ -20,8 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             initialVC.managedObjectContext = persistentContainer.viewContext
         }
         
-        if UserDefaults.standard.object(forKey: "shouldAutoRefresh") == nil {
-            UserDefaults.standard.set(true, forKey: "shouldAutoRefresh")
+        if DefaultsManager.shouldAutoRefresh == nil {
+            DefaultsManager.shouldAutoRefresh = true
         }
 
         return true

--- a/aw/AppDelegate.swift
+++ b/aw/AppDelegate.swift
@@ -19,6 +19,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if var initialVC = window?.rootViewController as? MOCViewControllerType {
             initialVC.managedObjectContext = persistentContainer.viewContext
         }
+        
+        if UserDefaults.standard.object(forKey: "shouldAutoRefresh") == nil {
+            UserDefaults.standard.set(true, forKey: "shouldAutoRefresh")
+        }
 
         return true
     }

--- a/aw/Helpers/DefaultsManager.swift
+++ b/aw/Helpers/DefaultsManager.swift
@@ -2,6 +2,16 @@ import Foundation
 
 class DefaultsManager {
 
+    private static let shouldAutoRefreshKey = "shouldAutoRefresh"
+    static var shouldAutoRefresh: Bool? {
+        get {
+            return UserDefaults.standard.object(forKey: shouldAutoRefreshKey) as? Bool
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: shouldAutoRefreshKey)
+        }
+    }
+    
     private static let onboardingCompletedKey = "onboardingCompletedKey"
     static var onboardingCompleted: Bool {
         get {

--- a/aw/ViewControllers/More/MoreTableViewController.swift
+++ b/aw/ViewControllers/More/MoreTableViewController.swift
@@ -5,7 +5,7 @@ class MoreTableViewController: UITableViewController {
     @IBOutlet weak var autoRefreshToggle: UISwitch!
     
     @IBAction func refreshToggled(_ sender: UISwitch) {
-        UserDefaults.standard.set(sender.isOn, forKey: "shouldAutoRefresh")
+        DefaultsManager.shouldAutoRefresh = sender.isOn
     }
     
     override func viewDidLoad() {
@@ -16,7 +16,7 @@ class MoreTableViewController: UITableViewController {
             self.version.text = "v \(version)"
         }
         
-        autoRefreshToggle.setOn(UserDefaults.standard.bool(forKey: "shouldAutoRefresh"), animated: false)
+        autoRefreshToggle.setOn(DefaultsManager.shouldAutoRefresh!, animated: false)
     }
 
     // MARK: - Table view data source

--- a/aw/ViewControllers/More/MoreTableViewController.swift
+++ b/aw/ViewControllers/More/MoreTableViewController.swift
@@ -3,6 +3,10 @@ import UIKit
 class MoreTableViewController: UITableViewController {
     @IBOutlet weak var version: UILabel!
     
+    @IBAction func refreshToggled(_ sender: UISwitch) {
+        UserDefaults.standard.set(sender.isOn, forKey: "shouldAutoRefresh")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -18,7 +22,7 @@ class MoreTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 5
+        return 6
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -50,6 +54,14 @@ class MoreTableViewController: UITableViewController {
         default:
             break
         }
+    }
+    
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        if indexPath.row == 5 {
+            return false
+        }
+        
+        return true
     }
     
     func openUrl(url: String) {

--- a/aw/ViewControllers/More/MoreTableViewController.swift
+++ b/aw/ViewControllers/More/MoreTableViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class MoreTableViewController: UITableViewController {
     @IBOutlet weak var version: UILabel!
+    @IBOutlet weak var autoRefreshToggle: UISwitch!
     
     @IBAction func refreshToggled(_ sender: UISwitch) {
         UserDefaults.standard.set(sender.isOn, forKey: "shouldAutoRefresh")
@@ -14,6 +15,8 @@ class MoreTableViewController: UITableViewController {
         if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
             self.version.text = "v \(version)"
         }
+        
+        autoRefreshToggle.setOn(UserDefaults.standard.bool(forKey: "shouldAutoRefresh"), animated: false)
     }
 
     // MARK: - Table view data source

--- a/aw/ViewControllers/Reaches/FavoriteListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/FavoriteListTableViewController.swift
@@ -1,8 +1,6 @@
 import UIKit
 
 class FavoriteListTableViewController: RunListTableViewController {
-    let UPDATE_INTERVAL_s: Double = 3600
-
     override func viewDidLoad() {
         predicates.append(NSPredicate(format: "favorite = TRUE" ))
         super.viewDidLoad()

--- a/aw/ViewControllers/Reaches/RunListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/RunListTableViewController.swift
@@ -2,6 +2,8 @@ import CoreData
 import UIKit
 
 class RunListTableViewController: UIViewController, MOCViewControllerType {
+    let UPDATE_INTERVAL_s: Double = 60 * 60 // 1 hour
+    
     @IBOutlet var tableView: UITableView!
     @IBOutlet weak var toggleView: UIView?
     @IBOutlet weak var runnableToggle: UISwitch?
@@ -47,10 +49,17 @@ class RunListTableViewController: UIViewController, MOCViewControllerType {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        guard DefaultsManager.lastUpdated != nil else {
+        
+        if let lastUpdated = DefaultsManager.lastUpdated {
+            // If data is stale
+            let isAutoRefreshEnabled = UserDefaults.standard.bool(forKey: "shouldAutoRefresh")
+            if isAutoRefreshEnabled && lastUpdated < Date().addingTimeInterval( -UPDATE_INTERVAL_s ) {
+                refreshReaches(sender: nil)
+            }
+            
+        // If there has never been an update
+        } else {
             refreshReaches(sender: nil)
-            return
         }
     }
 

--- a/aw/ViewControllers/Reaches/RunListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/RunListTableViewController.swift
@@ -50,9 +50,8 @@ class RunListTableViewController: UIViewController, MOCViewControllerType {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        if let lastUpdated = DefaultsManager.lastUpdated {
+        if let lastUpdated = DefaultsManager.lastUpdated, let isAutoRefreshEnabled = DefaultsManager.shouldAutoRefresh {
             // If data is stale
-            let isAutoRefreshEnabled = UserDefaults.standard.bool(forKey: "shouldAutoRefresh")
             if isAutoRefreshEnabled && lastUpdated < Date().addingTimeInterval( -UPDATE_INTERVAL_s ) {
                 refreshReaches(sender: nil)
             }

--- a/aw/aw/Base.lproj/About.storyboard
+++ b/aw/aw/Base.lproj/About.storyboard
@@ -28,7 +28,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="XUz-k5-aWQ">
-                            <rect key="frame" x="0.0" y="273" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="317" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FtY-gy-gct">
@@ -155,6 +155,30 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="WSz-4z-7wY">
+                                        <rect key="frame" x="0.0" y="255" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WSz-4z-7wY" id="eNU-ME-Uah">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWG-nX-es8">
+                                                    <rect key="frame" x="312" y="6" width="49" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <connections>
+                                                        <action selector="refreshToggled:" destination="8Rh-nN-QxN" eventType="valueChanged" id="Hey-jJ-yse"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Auto refresh flows" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BJQ-SY-hCw">
+                                                    <rect key="frame" x="60" y="12" width="244" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
+                                                    <color key="textColor" name="font_black"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -171,6 +195,12 @@
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MdM-iW-RG1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <view contentMode="scaleToFill" id="CZj-YY-h7n">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <viewLayoutGuide key="safeArea" id="h5y-DS-kpp"/>
+                </view>
             </objects>
             <point key="canvasLocation" x="4685.6000000000004" y="901.79910044977521"/>
         </scene>
@@ -796,6 +826,9 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
         <image name="rateApp" width="30" height="29"/>
         <namedColor name="accent">
             <color red="0.95294117647058818" green="0.36078431372549019" blue="0.28627450980392155" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="font_black">
+            <color red="0.15294117647058825" green="0.23137254901960785" blue="0.29803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="font_black">
             <color red="0.15294117647058825" green="0.23137254901960785" blue="0.29803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/aw/aw/Base.lproj/About.storyboard
+++ b/aw/aw/Base.lproj/About.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="u64-i6-RHT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="u64-i6-RHT">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -31,8 +31,8 @@
                             <rect key="frame" x="0.0" y="273" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FtY-gy-gct">
-                                    <rect key="frame" x="15" y="0.0" width="360" height="44"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FtY-gy-gct">
+                                    <rect key="frame" x="15" y="0.0" width="346" height="44"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>

--- a/aw/aw/Base.lproj/About.storyboard
+++ b/aw/aw/Base.lproj/About.storyboard
@@ -191,6 +191,7 @@
                         <barButtonItem key="backBarButtonItem" title="Back" id="JTf-qT-5PO"/>
                     </navigationItem>
                     <connections>
+                        <outlet property="autoRefreshToggle" destination="uWG-nX-es8" id="bgx-dt-7qs"/>
                         <outlet property="version" destination="FtY-gy-gct" id="yoU-Ic-hFs"/>
                     </connections>
                 </tableViewController>


### PR DESCRIPTION
This PR adds a toggle to the "more" page that allows a user to enable or disable auto refresh for flows. It defaults to "on", and will refresh when the user enters the run list page if the data is more than an hour old. There was probably a more elegant way to do the view, but I didn't want to spend more time wrestling with IB. 

I'm getting a ton of support requests right now asking why flows aren't updating, so I think that auto refresh that's on by default is necessary from a UX perspective. However, I agree with you that I would like to find a solution that doesn't use as much data. Hopefully the new mobile api will be an improvement, but if you have any suggestions in the mean time, I'm all ears. 