### PR TITLE
Don't implicitly unwrap mapViews

### DIFF
--- a/aw/ViewControllers/Reaches/Detail/ReachDetailMapViewController.swift
+++ b/aw/ViewControllers/Reaches/Detail/ReachDetailMapViewController.swift
@@ -3,7 +3,7 @@ import MapKit
 import UIKit
 
 class ReachDetailMapViewController: UIViewController {
-    @IBOutlet weak var mapView: MKMapView!
+    @IBOutlet weak var mapView: MKMapView?
 
     var managedObjectContext: NSManagedObjectContext?
     var reach: Reach?
@@ -19,7 +19,7 @@ class ReachDetailMapViewController: UIViewController {
     }
 
     @objc func showDirections(sender: UIButton) {
-        guard let annotation = mapView.selectedAnnotations.first as? RunAnnotation,
+        guard let mapView = mapView, let annotation = mapView.selectedAnnotations.first as? RunAnnotation,
             let reach = reach
             else { return }
 
@@ -29,13 +29,17 @@ class ReachDetailMapViewController: UIViewController {
     }
 
     deinit {
-        mapView.delegate = nil
+        if let mapView = mapView {
+            mapView.delegate = nil
+        }
     }
 }
 
 // MARK: - Extension
 extension ReachDetailMapViewController {
     func initialize() {
+        guard let mapView = mapView else { return }
+        
         mapView.mapType = .hybrid
         mapView.delegate = self
 
@@ -53,12 +57,16 @@ extension ReachDetailMapViewController {
     }
 
     func setupMap() {
+        guard let mapView = mapView else { return }
+        
         mapView.showsUserLocation = true
         mapView.layoutMargins = UIEdgeInsetsMake(0, 0, 40, 0)
         setupAnnotations()
     }
 
     func setupAnnotations() {
+        guard let mapView = mapView else { return }
+        
         if let reach = reach {
             if let lat = reach.putInLat,
                 let latitude = Double(lat),
@@ -103,6 +111,8 @@ extension ReachDetailMapViewController {
     }
 
     func reloadAnnotations() {
+        guard let mapView = mapView else { return }
+        
         mapView.removeAnnotations(mapView.annotations)
         setupAnnotations()
     }

--- a/aw/ViewControllers/Reaches/Detail/ReachDetailMapViewController.swift
+++ b/aw/ViewControllers/Reaches/Detail/ReachDetailMapViewController.swift
@@ -29,9 +29,9 @@ class ReachDetailMapViewController: UIViewController {
     }
 
     deinit {
-        if let mapView = mapView {
-            mapView.delegate = nil
-        }
+        guard let mapView = mapView else { return }
+        
+        mapView.delegate = nil
     }
 }
 
@@ -65,49 +65,48 @@ extension ReachDetailMapViewController {
     }
 
     func setupAnnotations() {
-        guard let mapView = mapView else { return }
+        guard let mapView = mapView,
+            let reach = reach else { return }
         
-        if let reach = reach {
-            if let lat = reach.putInLat,
-                let latitude = Double(lat),
-                let lon = reach.putInLon,
-                let longitude = Double(lon) {
-                let annotation = RunAnnotation(
-                    latitude: latitude,
-                    longitude: longitude,
-                    title: "Put In",
-                    subtitle: reach.section,
-                    type: .putIn)
-                mapView.addAnnotation(annotation)
-            }
+        if let lat = reach.putInLat,
+            let latitude = Double(lat),
+            let lon = reach.putInLon,
+            let longitude = Double(lon) {
+            let annotation = RunAnnotation(
+                latitude: latitude,
+                longitude: longitude,
+                title: "Put In",
+                subtitle: reach.section,
+                type: .putIn)
+            mapView.addAnnotation(annotation)
+        }
 
-            if let lat = reach.takeOutLat,
-                let latitude = Double(lat),
-                let lon = reach.takeOutLon,
-                let longitude = Double(lon) {
-                let annotation = RunAnnotation(
-                    latitude: latitude,
-                    longitude: longitude,
-                    title: "Take Out",
-                    subtitle: reach.section,
-                    type: .takeOut)
-                mapView.addAnnotation(annotation)
-            }
-            if let rapids = reach.rapids {
-                for rapid in rapids {
-                    if let rapid = rapid as? Rapid, rapid.lat != 0, rapid.lon != 0 {
-                        let annotation = RunAnnotation(
-                            latitude: rapid.lat,
-                            longitude: rapid.lon,
-                            title: "\(rapid.name ?? "") \(rapid.difficulty ?? "")",
-                            subtitle: nil,
-                            type: .rapid)
-                        mapView.addAnnotation(annotation)
-                    }
+        if let lat = reach.takeOutLat,
+            let latitude = Double(lat),
+            let lon = reach.takeOutLon,
+            let longitude = Double(lon) {
+            let annotation = RunAnnotation(
+                latitude: latitude,
+                longitude: longitude,
+                title: "Take Out",
+                subtitle: reach.section,
+                type: .takeOut)
+            mapView.addAnnotation(annotation)
+        }
+        if let rapids = reach.rapids {
+            for rapid in rapids {
+                if let rapid = rapid as? Rapid, rapid.lat != 0, rapid.lon != 0 {
+                    let annotation = RunAnnotation(
+                        latitude: rapid.lat,
+                        longitude: rapid.lon,
+                        title: "\(rapid.name ?? "") \(rapid.difficulty ?? "")",
+                        subtitle: nil,
+                        type: .rapid)
+                    mapView.addAnnotation(annotation)
                 }
             }
-            mapView.showAnnotations(mapView.annotations, animated: true)
         }
+        mapView.showAnnotations(mapView.annotations, animated: true)
     }
 
     func reloadAnnotations() {

--- a/aw/ViewControllers/Reaches/MapViewController.swift
+++ b/aw/ViewControllers/Reaches/MapViewController.swift
@@ -40,9 +40,9 @@ class MapViewController: UIViewController, MOCViewControllerType {
     }
 
     deinit {
-        if let mapView = mapView {
-            mapView.delegate = nil
-        }
+        guard let mapView = mapView else { return }
+        
+        mapView.delegate = nil
     }
 }
 
@@ -72,10 +72,10 @@ extension MapViewController {
     }
 
     func setupMapView() {
-        if let mapView = mapView {
-            mapView.delegate = self
-            mapView.showsUserLocation = true
-        }
+        guard let mapView = mapView else { return }
+        
+        mapView.delegate = self
+        mapView.showsUserLocation = true
     }
 
     func prepareDetailSegue(_ segue: UIStoryboardSegue) {

--- a/aw/ViewControllers/Reaches/MapViewController.swift
+++ b/aw/ViewControllers/Reaches/MapViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import MapKit
 
 class MapViewController: UIViewController, MOCViewControllerType {
-    @IBOutlet weak var mapView: MKMapView!
+    @IBOutlet weak var mapView: MKMapView?
     @IBOutlet weak var filterButton: UIBarButtonItem?
 
     var managedObjectContext: NSManagedObjectContext?
@@ -40,7 +40,9 @@ class MapViewController: UIViewController, MOCViewControllerType {
     }
 
     deinit {
-        mapView.delegate = nil
+        if let mapView = mapView {
+            mapView.delegate = nil
+        }
     }
 }
 
@@ -70,12 +72,14 @@ extension MapViewController {
     }
 
     func setupMapView() {
-        mapView.delegate = self
-        mapView.showsUserLocation = true
+        if let mapView = mapView {
+            mapView.delegate = self
+            mapView.showsUserLocation = true
+        }
     }
 
     func prepareDetailSegue(_ segue: UIStoryboardSegue) {
-        if let selectedReach = mapView.selectedAnnotations.first as? Reach,
+        if let mapView = mapView, let selectedReach = mapView.selectedAnnotations.first as? Reach,
             let context = managedObjectContext {
             let request: NSFetchRequest<Reach> = Reach.fetchRequest()
             request.predicate = NSPredicate(format: "id = %i", selectedReach.id)
@@ -100,7 +104,8 @@ extension MapViewController {
         let regions = DefaultsManager.regionsFilter
         let distance = DefaultsManager.distanceFilter
 
-        guard difficulties != self.difficulties || regions != self.regions || distance != self.distance else { return }
+        guard let mapView = mapView,
+            difficulties != self.difficulties || regions != self.regions || distance != self.distance else { return }
 
         if regions != self.regions || distance != self.distance {
             zoom = true
@@ -218,7 +223,8 @@ extension MapViewController: NSFetchedResultsControllerDelegate {
                     at indexPath: IndexPath?,
                     for type: NSFetchedResultsChangeType,
                     newIndexPath: IndexPath?) {
-        guard let reach = anObject as? Reach else {
+        guard let reach = anObject as? Reach,
+            let mapView = mapView else {
             print("not a reach")
             return
         }


### PR DESCRIPTION
It looks like the maps are now sometimes crashing when trying to deinit if the mapView is already been destroyed. This changes the mapView to be a regular optional and unwraps where appropriate.