### PR TITLE
Segue to gage detail from favorites.

### DIFF
--- a/aw/Base.lproj/Main.storyboard
+++ b/aw/Base.lproj/Main.storyboard
@@ -915,7 +915,8 @@
                         <outlet property="tableView" destination="9py-7s-WQq" id="0ph-8b-s6G"/>
                         <outlet property="updateTimeLabel" destination="S9h-zB-2tj" id="uaH-x4-Qsd"/>
                         <outlet property="updateTimeView" destination="gmY-XI-hxh" id="thb-pv-C7c"/>
-                        <segue destination="lOP-Q4-YiZ" kind="show" identifier="runDetailFavorites" id="n1I-mv-LT1"/>
+                        <segue destination="oyk-GY-GuU" kind="show" identifier="gageDetail" id="ZPw-eR-cyG"/>
+                        <segue destination="lOP-Q4-YiZ" kind="show" identifier="runDetail" id="pvQ-ZH-6yS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="T7X-XK-xtp" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1721,8 +1722,9 @@
         </namedColor>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="ZPw-eR-cyG"/>
         <segue reference="vCc-Lg-GX5"/>
         <segue reference="HLz-3E-X9y"/>
-        <segue reference="kal-PE-jUf"/>
+        <segue reference="pvQ-ZH-6yS"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/aw/ViewControllers/Reaches/FavoriteListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/FavoriteListTableViewController.swift
@@ -47,6 +47,13 @@ class FavoriteListTableViewController: RunListTableViewController {
     }
 
     override func segueDetail() {
-        performSegue(withIdentifier: Segue.runDetailFavorites.rawValue, sender: self)
+        guard let indexPath = tableView.indexPathForSelectedRow,
+            let reach = fetchedResultsController?.fetchedObjects![indexPath.row] else { return }
+        
+        if (reach.gageId == 0) {
+            performSegue(withIdentifier: Segue.runDetail.rawValue, sender: self)
+        } else {
+            performSegue(withIdentifier: Segue.gageDetail.rawValue, sender: self)
+        }
     }
 }

--- a/aw/ViewControllers/Reaches/RunListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/RunListTableViewController.swift
@@ -69,7 +69,7 @@ class RunListTableViewController: UIViewController, MOCViewControllerType {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         switch segue.identifier! {
-        case Segue.runDetail.rawValue, Segue.runDetailFavorites.rawValue:
+        case Segue.runDetail.rawValue:
             guard let detailVC = segue.destination as? ReachDetailContainerViewController,
                 let indexPath = tableView.indexPathForSelectedRow,
                 let reach = fetchedResultsController?.fetchedObjects![indexPath.row] else { return }

--- a/aw/ViewControllers/Reaches/RunListTableViewController.swift
+++ b/aw/ViewControllers/Reaches/RunListTableViewController.swift
@@ -76,6 +76,13 @@ class RunListTableViewController: UIViewController, MOCViewControllerType {
 
             detailVC.reach = reach
             injectContextAndContainerToChildVC(segue: segue)
+        case Segue.gageDetail.rawValue:
+            guard let gageVC = segue.destination as? GageViewController,
+                let indexPath = tableView.indexPathForSelectedRow,
+                let reach = fetchedResultsController?.fetchedObjects![indexPath.row] else { return }
+            
+            gageVC.sourceReach = reach
+            injectContextAndContainerToChildVC(segue: segue)
         case Segue.showFilters.rawValue, Segue.showFiltersFavorites.rawValue:
             injectContextAndContainerToNavChildVC(segue: segue)
         default:


### PR DESCRIPTION
This PR changes the segue from Favorites to preferentially go to the gage detail page. If the selected reach does not have a gage, the app will navigate to the run detail instead. 