### PR TITLE
Allow use of the app without location permissions

### DIFF
--- a/American Whitewater.xcodeproj/project.pbxproj
+++ b/American Whitewater.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2FE342CE26A1FF8100352D1E /* UIViewController+Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE342CD26A1FF8100352D1E /* UIViewController+Toast.swift */; };
+		2FE342D026A2846100352D1E /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE342CF26A2846100352D1E /* Location.swift */; };
 		4760DD5C0E5548BBA92D25AF /* Pods_American_Whitewater.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A750E2F24748D3B54A1DEB84 /* Pods_American_Whitewater.framework */; };
 		4AC4BB5A26A0F5B50058D8B7 /* NewsArticle+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4BB5826A0F5B50058D8B7 /* NewsArticle+CoreDataClass.swift */; };
 		4AC4BB5B26A0F5B50058D8B7 /* NewsArticle+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4BB5926A0F5B50058D8B7 /* NewsArticle+CoreDataProperties.swift */; };
@@ -149,6 +151,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2FE342CD26A1FF8100352D1E /* UIViewController+Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Toast.swift"; sourceTree = "<group>"; };
+		2FE342CF26A2846100352D1E /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		4AC4BB5826A0F5B50058D8B7 /* NewsArticle+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NewsArticle+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4AC4BB5926A0F5B50058D8B7 /* NewsArticle+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NewsArticle+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		630586632350428800A436BE /* RunRapidDetailsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunRapidDetailsTableViewController.swift; sourceTree = "<group>"; };
@@ -497,6 +501,7 @@
 				631644A1246ED80B00807E19 /* UIButton+UrlImageLoad.swift */,
 				6316449F246ED6B100807E19 /* UIImage+AsyncURLLoad.swift */,
 				63432D452540DA340037AA37 /* UISegmentedControl+Colors.swift */,
+				2FE342CD26A1FF8100352D1E /* UIViewController+Toast.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -604,6 +609,7 @@
 				63164495246C08AA00807E19 /* AWProgress.swift */,
 				6376508C2487E8AB00DD0FCE /* AWProgressModal.swift */,
 				63FF68FD25AE249100AF0F37 /* ChartXAxisFormatter.swift */,
+				2FE342CF26A2846100352D1E /* Location.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -917,6 +923,7 @@
 				63309E3D233E739C00E6DBC4 /* MapViewController.swift in Sources */,
 				63E32B1D2357F3260057DE34 /* FilterClassCollectionViewCell.swift in Sources */,
 				639350C22475929900577027 /* AddRiverFlowTableViewController.swift in Sources */,
+				2FE342D026A2846100352D1E /* Location.swift in Sources */,
 				63949955246F0DD40061552C /* AwImageCell.swift in Sources */,
 				63FF68C525ACF2A900AF0F37 /* GageGraphCell.swift in Sources */,
 				631EFF9A23677C4000BA17F7 /* Article+CoreDataProperties.swift in Sources */,
@@ -934,6 +941,7 @@
 				630F7EC825C3439000F17D8A /* LoadingRiversCell.swift in Sources */,
 				631EFFA223677CB600BA17F7 /* Rapid+CoreDataProperties.swift in Sources */,
 				63B5B4A324589EAB0062F54B /* RunAccidentsViewController.swift in Sources */,
+				2FE342CE26A1FF8100352D1E /* UIViewController+Toast.swift in Sources */,
 				4AC4BB5B26A0F5B50058D8B7 /* NewsArticle+CoreDataProperties.swift in Sources */,
 				63B5B49E2457B2270062F54B /* AwGraphQLAPI.swift in Sources */,
 				63D7BD1F231A205500935693 /* NewsTableViewController.swift in Sources */,

--- a/American Whitewater/Base.lproj/Main.storyboard
+++ b/American Whitewater/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DZd-kw-GNv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DZd-kw-GNv">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -317,31 +317,31 @@
                             </constraints>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="adP-ni-F3Z">
-                            <rect key="frame" x="0.0" y="679" width="375" height="1"/>
+                            <rect key="frame" x="0.0" y="672.00000034679067" width="375" height="1"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="NewsCell" rowHeight="109" id="i2j-JX-ehV" customClass="NewsTableViewCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="262" width="375" height="109"/>
+                                <rect key="frame" x="0.0" y="258.5" width="375" height="109"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i2j-JX-ehV" id="gUo-G9-1XA">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="News Item" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="16" translatesAutoresizingMaskIntoConstraints="NO" id="vu6-uE-YN4">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="News Item" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="16" translatesAutoresizingMaskIntoConstraints="NO" id="vu6-uE-YN4">
                                             <rect key="frame" x="15" y="11" width="345" height="29"/>
                                             <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="21"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="author and date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8B5-B2-AGJ">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="author and date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8B5-B2-AGJ">
                                             <rect key="frame" x="15" y="40" width="345" height="18"/>
                                             <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="13"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="abstract" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="538-IZ-aVu">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="abstract" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="538-IZ-aVu">
                                             <rect key="frame" x="15" y="73" width="345" height="22"/>
                                             <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                             <nil key="textColor"/>
@@ -368,7 +368,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="NewsCell2" rowHeight="280" id="GRx-sZ-whH" customClass="NewsTableViewCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="371" width="375" height="280"/>
+                                <rect key="frame" x="0.0" y="367.5" width="375" height="280"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GRx-sZ-whH" id="6PJ-P7-rQC">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="280"/>
@@ -484,7 +484,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="w3y-SK-HwH">
-                            <rect key="frame" x="0.0" y="441" width="375" height="65"/>
+                            <rect key="frame" x="0.0" y="427.00000069358134" width="375" height="65"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KV6-xY-22y">
@@ -511,7 +511,7 @@
                             <tableViewSection id="o55-rw-a6m">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="titleCell" rowHeight="74" id="qpm-he-uYF">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="74"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="74"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qpm-he-uYF" id="7aB-mb-ZYo">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="74"/>
@@ -549,7 +549,7 @@
                             <tableViewSection headerTitle="" id="4PM-HH-d3f">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="MUN-9v-VVl" detailTextLabel="AVZ-Wb-BV0" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="pjy-V2-p1g">
-                                        <rect key="frame" x="0.0" y="158" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="147.50000034679067" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pjy-V2-p1g" id="pUc-eg-zfE">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
@@ -573,7 +573,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="201" id="fpF-FA-UjH">
-                                        <rect key="frame" x="0.0" y="212" width="375" height="201"/>
+                                        <rect key="frame" x="0.0" y="201.50000034679067" width="375" height="201"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fpF-FA-UjH" id="HDy-Aa-XJ5">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="201"/>
@@ -648,7 +648,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q5s-Pg-EbQ">
-                                <rect key="frame" x="10" y="250" width="355" height="324"/>
+                                <rect key="frame" x="10" y="255" width="355" height="319"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -656,13 +656,13 @@
                                 </wkWebViewConfiguration>
                             </wkWebView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q84-We-ILu">
-                                <rect key="frame" x="20" y="200" width="335" height="28"/>
+                                <rect key="frame" x="20" y="200" width="335" height="33"/>
                                 <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By: Author - Date Posted" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xY8-Lc-vOn">
-                                <rect key="frame" x="20" y="228" width="335" height="17"/>
+                                <rect key="frame" x="20" y="233" width="335" height="17"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="17" id="MhM-Rs-7pV"/>
                                 </constraints>
@@ -736,7 +736,7 @@
                         <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GageDetailOverviewCell" rowHeight="120" id="hTp-A1-Dmm" customClass="GageDetailsCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="120"/>
+                                <rect key="frame" x="0.0" y="24.5" width="375" height="120"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hTp-A1-Dmm" id="ePj-uw-fJB">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -825,7 +825,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GageGraphCell" rowHeight="317" id="yUD-YH-cwX" customClass="GageGraphCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="148" width="375" height="317"/>
+                                <rect key="frame" x="0.0" y="144.5" width="375" height="317"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yUD-YH-cwX" id="z1Q-eg-HGP">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="317"/>
@@ -862,20 +862,20 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GageForRunCell" rowHeight="80" id="Mxm-rW-RFG" customClass="GageForRunCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="465" width="375" height="80"/>
+                                <rect key="frame" x="0.0" y="461.5" width="375" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Mxm-rW-RFG" id="538-Tq-CKS">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="80"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="M6X-LF-gf6">
-                                            <rect key="frame" x="16" y="11" width="343" height="20"/>
+                                            <rect key="frame" x="16" y="11" width="343" height="23.5"/>
                                             <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="teB-Jt-ChZ">
-                                            <rect key="frame" x="16" y="33" width="343" height="14"/>
+                                            <rect key="frame" x="16" y="36.5" width="343" height="16.5"/>
                                             <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="12"/>
                                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
@@ -920,7 +920,7 @@
                             <tableViewSection headerTitle="" id="cpm-Cm-DvA">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="106" id="Cyp-lH-ZB5">
-                                        <rect key="frame" x="0.0" y="39.5" width="375" height="106"/>
+                                        <rect key="frame" x="0.0" y="35" width="375" height="106"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Cyp-lH-ZB5" id="EYP-0v-tmR">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="106"/>
@@ -1001,14 +1001,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="45" id="Z4t-E9-JXW">
-                                        <rect key="frame" x="0.0" y="145.5" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="141" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Z4t-E9-JXW" id="toc-he-B9u">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="45"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View and Report Flows" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X7h-re-vQ2">
-                                                    <rect key="frame" x="20" y="0.0" width="328" height="45"/>
+                                                    <rect key="frame" x="20" y="0.0" width="329.5" height="45"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="45" id="PzU-TV-MhO"/>
                                                     </constraints>
@@ -1033,7 +1033,7 @@
                             <tableViewSection id="0rB-aW-w2b">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="85" id="E1t-b8-ntb">
-                                        <rect key="frame" x="0.0" y="226.5" width="375" height="85"/>
+                                        <rect key="frame" x="0.0" y="222" width="375" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="E1t-b8-ntb" id="Tey-VQ-WqQ">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="85"/>
@@ -1109,7 +1109,7 @@
                             <tableViewSection id="SF1-Is-ruz">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="180" id="pmx-e7-EfG">
-                                        <rect key="frame" x="0.0" y="347.5" width="375" height="180"/>
+                                        <rect key="frame" x="0.0" y="343" width="375" height="180"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pmx-e7-EfG" id="qq6-kO-fRk">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="180"/>
@@ -1135,7 +1135,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="67" id="kWt-Fq-ygB">
-                                        <rect key="frame" x="0.0" y="527.5" width="375" height="67"/>
+                                        <rect key="frame" x="0.0" y="523" width="375" height="67"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kWt-Fq-ygB" id="EhN-Ek-jI3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="67"/>
@@ -1174,10 +1174,10 @@
                                         <viewLayoutGuide key="safeArea" id="a6g-IQ-nJ6"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="80" id="evF-Bi-3xR">
-                                        <rect key="frame" x="0.0" y="594.5" width="375" height="80"/>
+                                        <rect key="frame" x="0.0" y="590" width="375" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="evF-Bi-3xR" id="g74-rP-0tM">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="80"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="80"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojo-oj-UgF">
@@ -1211,7 +1211,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pvg-0G-Nde">
-                                                    <rect key="frame" x="0.0" y="0.0" width="348" height="80"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="349.5" height="80"/>
                                                     <connections>
                                                         <action selector="photoGalleryButtonPressed:" destination="mFc-ar-6ha" eventType="touchUpInside" id="Hpl-32-q1f"/>
                                                     </connections>
@@ -1243,14 +1243,14 @@
                             <tableViewSection id="y2J-GS-y3L">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="QKo-ec-moN" style="IBUITableViewCellStyleDefault" id="8Z1-pj-GVP">
-                                        <rect key="frame" x="0.0" y="710.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="706" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8Z1-pj-GVP" id="XSk-hk-Mqq">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="River Alerts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QKo-ec-moN">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1260,14 +1260,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="2bY-UZ-skd" style="IBUITableViewCellStyleDefault" id="1sU-VR-4hD">
-                                        <rect key="frame" x="0.0" y="754.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="750" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1sU-VR-4hD" id="jKL-mf-icQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Accident Reports" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2bY-UZ-skd">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1277,14 +1277,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="LvI-wQ-4XB" style="IBUITableViewCellStyleDefault" id="tWV-cy-J3k">
-                                        <rect key="frame" x="0.0" y="798.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="794" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tWV-cy-J3k" id="Qvz-aX-4QS">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="See Gage Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="LvI-wQ-4XB">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1294,14 +1294,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Doc-sb-Abw" style="IBUITableViewCellStyleDefault" id="Sog-aW-2Wq">
-                                        <rect key="frame" x="0.0" y="842.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="838" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Sog-aW-2Wq" id="nHm-tU-cgL">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Go To Website" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Doc-sb-Abw">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1311,14 +1311,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Cmj-0U-b4L" style="IBUITableViewCellStyleDefault" id="Kja-zQ-J6r">
-                                        <rect key="frame" x="0.0" y="886.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="882" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Kja-zQ-J6r" id="DGz-WN-ooK">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Share" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Cmj-0U-b4L">
-                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="325.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1401,13 +1401,13 @@
                                 <rect key="frame" x="0.0" y="85" width="375" height="404"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="b3h-Tz-mMT">
-                                    <rect key="frame" x="0.0" y="611" width="375" height="1"/>
+                                    <rect key="frame" x="0.0" y="604.00000034679067" width="375" height="1"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RiverFlowCell" rowHeight="278" id="iEJ-Xn-Naj" customClass="RiverFlowCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="278"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="278"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iEJ-Xn-Naj" id="E6Z-tD-jfd">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="278"/>
@@ -1448,7 +1448,7 @@
                                                         <constraint firstAttribute="width" constant="30" id="xyf-5S-2WP"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="wEK-a9-ImO">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="wEK-a9-ImO">
                                                     <rect key="frame" x="20" y="202" width="335" height="23.5"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1457,14 +1457,14 @@
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sj2-W0-fif">
                                                     <rect key="frame" x="20" y="24" width="335" height="170"/>
                                                 </button>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Flow Range:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fLH-GD-1js">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Flow Range:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fLH-GD-1js">
                                                     <rect key="frame" x="20" y="232" width="186" height="17"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="12"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Gage Value:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iGz-Gt-nOY">
-                                                    <rect key="frame" x="226" y="238" width="129" height="14"/>
+                                                    <rect key="frame" x="226" y="233" width="129" height="16.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="129" id="XIz-tp-yD8"/>
                                                     </constraints>
@@ -1472,7 +1472,7 @@
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Too High - Not Boatable" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZB9-9b-3ap">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Too High - Not Boatable" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ZB9-9b-3ap">
                                                     <rect key="frame" x="20" y="251" width="186" height="17"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="186" id="1bM-L3-FUy"/>
@@ -1482,7 +1482,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10000cfs" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="104-Tl-Abl">
-                                                    <rect key="frame" x="226" y="254" width="129" height="14"/>
+                                                    <rect key="frame" x="226" y="251.5" width="129" height="16.5"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="12"/>
                                                     <color key="textColor" name="level_high"/>
                                                     <nil key="highlightedColor"/>
@@ -1531,7 +1531,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RiverFlowNoPicCell" rowHeight="107" id="zqw-Fn-I2F" customClass="RiverFlowCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="306" width="375" height="107"/>
+                                        <rect key="frame" x="0.0" y="302.5" width="375" height="107"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zqw-Fn-I2F" id="nfH-RL-V3e">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="107"/>
@@ -1556,13 +1556,13 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="4" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="M1e-sz-zsZ">
-                                                    <rect key="frame" x="20" y="30" width="335" height="20"/>
+                                                    <rect key="frame" x="20" y="30" width="335" height="23.5"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Flow Range:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDH-ZI-KBc">
-                                                    <rect key="frame" x="20" y="57.5" width="171" height="17"/>
+                                                    <rect key="frame" x="20" y="61" width="171" height="17"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="17" id="z7B-P6-XgW"/>
                                                     </constraints>
@@ -1571,13 +1571,13 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Too High - Not Boatable" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="JUb-D1-45v">
-                                                    <rect key="frame" x="20" y="75" width="171" height="20.5"/>
+                                                    <rect key="frame" x="20" y="78.5" width="171" height="17"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="12"/>
                                                     <color key="textColor" name="level_high"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Gage Value:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4xm-ed-cwI">
-                                                    <rect key="frame" x="227" y="64" width="128" height="17"/>
+                                                    <rect key="frame" x="227" y="61.5" width="128" height="17"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="17" id="GpS-D5-wad"/>
                                                         <constraint firstAttribute="width" constant="128" id="ylg-Nl-DWi"/>
@@ -1587,7 +1587,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10000cfs" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2Qh-Pq-FZV">
-                                                    <rect key="frame" x="227" y="83" width="128" height="14"/>
+                                                    <rect key="frame" x="227" y="80.5" width="128" height="16.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="128" id="1z5-xT-apy"/>
                                                     </constraints>
@@ -1626,7 +1626,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="NoRiverFlowCell" rowHeight="170" id="GV5-nq-tbj">
-                                        <rect key="frame" x="0.0" y="413" width="375" height="170"/>
+                                        <rect key="frame" x="0.0" y="409.5" width="375" height="170"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GV5-nq-tbj" id="h8D-4L-KhG">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="170"/>
@@ -1674,13 +1674,13 @@ Get Some River Karma and Report One Now!</string>
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="77"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="River Section" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="6b2-3k-Sae">
-                                        <rect key="frame" x="20" y="33" width="210" height="15.5"/>
+                                        <rect key="frame" x="20" y="37" width="210" height="18"/>
                                         <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="13"/>
                                         <color key="textColor" name="font_grey"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="River Name" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="MeQ-ae-Qg0">
-                                        <rect key="frame" x="20" y="12" width="210" height="21"/>
+                                        <rect key="frame" x="20" y="12" width="210" height="25"/>
                                         <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="18"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -2077,7 +2077,7 @@ Description: n/a</string>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="at8-jU-TA3" userLabel="empty view hack">
-                            <rect key="frame" x="0.0" y="771" width="375" height="1"/>
+                            <rect key="frame" x="0.0" y="757.00000069358134" width="375" height="1"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
@@ -2085,7 +2085,7 @@ Description: n/a</string>
                             <tableViewSection id="CeE-5G-in9">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="250" id="gCH-Dk-CVb">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="250"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="250"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gCH-Dk-CVb" id="171-B5-2go">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="250"/>
@@ -2108,7 +2108,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="74" id="OES-yW-hbt">
-                                        <rect key="frame" x="0.0" y="278" width="375" height="74"/>
+                                        <rect key="frame" x="0.0" y="274.5" width="375" height="74"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OES-yW-hbt" id="u4d-Cq-T7q">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="74"/>
@@ -2150,10 +2150,10 @@ Description: n/a</string>
                             <tableViewSection id="beX-Dh-ogH">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="52" id="PxX-kj-Bog">
-                                        <rect key="frame" x="0.0" y="408" width="375" height="52"/>
+                                        <rect key="frame" x="0.0" y="397.50000034679067" width="375" height="52"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PxX-kj-Bog" id="aLg-Ah-mUf">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="52"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="52"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Approx. Date/Time:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tWd-H6-p31">
@@ -2166,7 +2166,7 @@ Description: n/a</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="09/29/2020 03:20 PM" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ywm-bC-GYG">
-                                                    <rect key="frame" x="142" y="16" width="198" height="21"/>
+                                                    <rect key="frame" x="142" y="16" width="199.5" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                     <color key="textColor" name="primary"/>
                                                     <nil key="highlightedColor"/>
@@ -2183,10 +2183,10 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="52" id="mDv-IA-zcv">
-                                        <rect key="frame" x="0.0" y="460" width="375" height="52"/>
+                                        <rect key="frame" x="0.0" y="449.50000034679067" width="375" height="52"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mDv-IA-zcv" id="ENn-Ko-Zz4">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="52"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="52"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Level Observation:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gIL-Mf-Nyu">
@@ -2199,7 +2199,7 @@ Description: n/a</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Observation" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2eZ-hT-tCK">
-                                                    <rect key="frame" x="144" y="16" width="196" height="21"/>
+                                                    <rect key="frame" x="144" y="16" width="197.5" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                     <color key="textColor" name="primary"/>
                                                     <nil key="highlightedColor"/>
@@ -2216,7 +2216,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="56" id="d9V-lg-7Im">
-                                        <rect key="frame" x="0.0" y="512" width="375" height="56"/>
+                                        <rect key="frame" x="0.0" y="501.50000034679067" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="d9V-lg-7Im" id="g8I-Ud-CSj">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
@@ -2251,7 +2251,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="130" id="BRs-Ls-AQA">
-                                        <rect key="frame" x="0.0" y="568" width="375" height="130"/>
+                                        <rect key="frame" x="0.0" y="557.50000034679067" width="375" height="130"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BRs-Ls-AQA" id="qVx-RL-Tbd">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="130"/>
@@ -2286,7 +2286,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="45" id="TFf-rx-bow">
-                                        <rect key="frame" x="0.0" y="698" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="687.50000034679067" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TFf-rx-bow" id="vst-5H-WgO">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -2412,7 +2412,7 @@ Description: n/a</string>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="alertCell" rowHeight="70" id="VjV-Tw-K3k" customClass="AlertTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VjV-Tw-K3k" id="rXM-P0-w9l">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -2469,7 +2469,7 @@ Description: n/a</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="noAlertCell" rowHeight="70" id="s9b-I5-wy5">
-                                        <rect key="frame" x="0.0" y="98" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="94.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="s9b-I5-wy5" id="5cq-Ak-qa1">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -2491,7 +2491,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="loadingAlertCell" rowHeight="70" id="S0b-KQ-5nn">
-                                        <rect key="frame" x="0.0" y="168" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="164.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="S0b-KQ-5nn" id="tNz-5L-WnO">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -2721,7 +2721,7 @@ Description: n/a</string>
                                                         </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Flow Legend:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jNq-sa-Biu">
-                                                        <rect key="frame" x="118" y="8" width="109" height="25"/>
+                                                        <rect key="frame" x="116" y="8" width="113" height="25"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="25" id="FPi-zs-9Zu"/>
                                                         </constraints>
@@ -2773,13 +2773,13 @@ Description: n/a</string>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="SPn-8e-k5M">
-                                    <rect key="frame" x="0.0" y="458" width="375" height="1"/>
+                                    <rect key="frame" x="0.0" y="451.00000034679067" width="375" height="1"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RunCell" rowHeight="120" id="uF9-W9-eVy" customClass="RunsListTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="120"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uF9-W9-eVy" id="917-Tu-t0D">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -2793,7 +2793,7 @@ Description: n/a</string>
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="River Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YXi-uT-aJa">
-                                                    <rect key="frame" x="27" y="11" width="285" height="20"/>
+                                                    <rect key="frame" x="27" y="11" width="285" height="23.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="Cdo-sg-N7e"/>
                                                     </constraints>
@@ -2818,7 +2818,7 @@ Description: n/a</string>
                                                     <state key="normal" image="icon_favorite"/>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="River Section" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QzN-A8-hj6">
-                                                    <rect key="frame" x="27" y="39" width="257" height="44.5"/>
+                                                    <rect key="frame" x="27" y="42.5" width="257" height="41"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_grey"/>
                                                     <nil key="highlightedColor"/>
@@ -2872,7 +2872,7 @@ Description: n/a</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="NoRiversCell" rowHeight="162" id="HgA-m3-6hE" customClass="NoRiversTableViewCell" customModule="AW">
-                                        <rect key="frame" x="0.0" y="148" width="375" height="162"/>
+                                        <rect key="frame" x="0.0" y="144.5" width="375" height="162"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HgA-m3-6hE" id="bah-Xf-YWZ">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="162"/>
@@ -2929,14 +2929,14 @@ and check your internet connection.</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="LoadingRiversCell" rowHeight="120" id="0g5-UQ-jQ0" customClass="LoadingRiversCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="310" width="375" height="120"/>
+                                        <rect key="frame" x="0.0" y="306.5" width="375" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0g5-UQ-jQ0" id="QUb-7x-kkS">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading River Data..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AiK-xU-FUe">
-                                                    <rect key="frame" x="98.5" y="14" width="178.5" height="26"/>
+                                                    <rect key="frame" x="93.5" y="14" width="188.5" height="26"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="19"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -3321,11 +3321,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="18" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hH3-7h-Vas" id="9ni-QJ-Fq0">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="About American Whitewater" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="33Y-my-bdS">
-                                                    <rect key="frame" x="60" y="0.0" width="280" height="44"/>
+                                                    <rect key="frame" x="60" y="0.0" width="281.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3345,11 +3345,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="62" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tpY-OE-MCH" id="53L-mB-C9o">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App Team" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="HXt-rF-1Em">
-                                                    <rect key="frame" x="61" y="0.0" width="279" height="44"/>
+                                                    <rect key="frame" x="61" y="0.0" width="280.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3369,11 +3369,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="106" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TxO-gG-ING" id="VKW-A8-gWD">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Rate this App" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="v1b-H4-R8M">
-                                                    <rect key="frame" x="61" y="0.0" width="279" height="44"/>
+                                                    <rect key="frame" x="61" y="0.0" width="280.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3390,11 +3390,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="150" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZZO-7h-woe" id="z6x-S8-o3H">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3EA-SE-kuX">
-                                                    <rect key="frame" x="61" y="0.0" width="279" height="44"/>
+                                                    <rect key="frame" x="61" y="0.0" width="280.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3411,11 +3411,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="194" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ShU-Mi-LZO" id="PqJ-OM-xyS">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Donate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="JXf-qh-Zkn">
-                                                    <rect key="frame" x="60" y="0.0" width="280" height="44"/>
+                                                    <rect key="frame" x="60" y="0.0" width="281.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3432,7 +3432,7 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="238" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mb0-8w-R5d" id="6ss-zz-Tt2">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign In" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N0g-Nm-CE2">
@@ -3625,7 +3625,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                             <tableViewSection id="0mZ-tW-31Z">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="RNQ-8W-cuC">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RNQ-8W-cuC" id="haZ-zO-G8g">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -3633,7 +3633,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="iP6-kx-cDr">
-                                        <rect key="frame" x="0.0" y="72" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="68.5" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iP6-kx-cDr" id="BFp-c8-hgf">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3655,7 +3655,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                                     <color key="textColor" name="font_black"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ya Manager" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0JC-4s-sxb">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Engineer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0JC-4s-sxb">
                                                     <rect key="frame" x="91" y="43" width="121" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="121" id="CCY-ZD-J6M"/>
@@ -3690,7 +3690,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="vI5-m4-ssd">
-                                        <rect key="frame" x="0.0" y="170" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="166.5" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vI5-m4-ssd" id="Km2-vO-SMj">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3747,7 +3747,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="nhf-zA-nfd">
-                                        <rect key="frame" x="0.0" y="268" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="264.5" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nhf-zA-nfd" id="jN1-3k-ho3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3804,7 +3804,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="PNt-EJ-AxU">
-                                        <rect key="frame" x="0.0" y="366" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="362.5" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PNt-EJ-AxU" id="lsV-FW-DbL">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3861,7 +3861,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="PQK-4O-z4F">
-                                        <rect key="frame" x="0.0" y="464" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="460.5" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PQK-4O-z4F" id="1KJ-wg-yXB">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3880,7 +3880,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="689" id="bce-Xo-Na5">
-                                        <rect key="frame" x="0.0" y="562" width="375" height="689"/>
+                                        <rect key="frame" x="0.0" y="558.5" width="375" height="689"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bce-Xo-Na5" id="YCf-LA-bIa">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="689"/>
@@ -3987,13 +3987,13 @@ Special thanks to the following people for making this app a reality:       
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
                                 <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="8fn-bN-bd8">
-                                    <rect key="frame" x="0.0" y="176" width="375" height="1"/>
+                                    <rect key="frame" x="0.0" y="169.00000034679067" width="375" height="1"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="FavRunCell" rowHeight="120" id="len-1w-eIL" customClass="RunsListTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="120"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="len-1w-eIL" id="q1H-xO-u41">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -4265,7 +4265,7 @@ Special thanks to the following people for making this app a reality:       
                             <tableViewSection headerTitle="" id="SjA-uU-8bv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="59" id="FHG-lM-rg1">
-                                        <rect key="frame" x="0.0" y="39.5" width="375" height="59"/>
+                                        <rect key="frame" x="0.0" y="35" width="375" height="59"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="FHG-lM-rg1" id="qeK-kC-hok">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="59"/>
@@ -4291,7 +4291,7 @@ Special thanks to the following people for making this app a reality:       
                             <tableViewSection id="Y6y-pr-0T5">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="95" id="tvw-07-Zcj">
-                                        <rect key="frame" x="0.0" y="134.5" width="375" height="95"/>
+                                        <rect key="frame" x="0.0" y="130" width="375" height="95"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tvw-07-Zcj" id="XBY-NQ-RPP">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="95"/>
@@ -4333,7 +4333,7 @@ Special thanks to the following people for making this app a reality:       
                             <tableViewSection id="Myr-CQ-j0v">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="85" id="Fc0-nm-CXY">
-                                        <rect key="frame" x="0.0" y="265.5" width="375" height="85"/>
+                                        <rect key="frame" x="0.0" y="261" width="375" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Fc0-nm-CXY" id="HdG-qg-Vc7">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="85"/>
@@ -4507,14 +4507,14 @@ Special thanks to the following people for making this app a reality:       
                                                             <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                                             <prototypes>
                                                                 <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="checkmark" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RegionCell" textLabel="pLs-75-mFz" style="IBUITableViewCellStyleDefault" id="ZjK-EK-BPJ">
-                                                                    <rect key="frame" x="0.0" y="55.5" width="375" height="43.5"/>
+                                                                    <rect key="frame" x="0.0" y="49.5" width="375" height="46.5"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZjK-EK-BPJ" id="dPN-IH-l2D">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="43.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="338.5" height="46.5"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pLs-75-mFz">
-                                                                                <rect key="frame" x="16" y="0.0" width="311" height="43.5"/>
+                                                                                <rect key="frame" x="16" y="0.0" width="314.5" height="46.5"/>
                                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                                 <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="17"/>
                                                                                 <nil key="textColor"/>
@@ -5151,10 +5151,10 @@ Don't worry, you'll be checking levels in no time!</string>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="accidentCell" rowHeight="106" id="d4P-pw-tCg" customClass="AccidentTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="106"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="106"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="d4P-pw-tCg" id="YxV-dT-DQ2">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="106"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="106"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="057-m8-ghS">
@@ -5167,7 +5167,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Eo3-Cg-MvM">
-                                                    <rect key="frame" x="20" y="28" width="320" height="70"/>
+                                                    <rect key="frame" x="20" y="28" width="321.5" height="70"/>
                                                     <attributedString key="attributedText">
                                                         <fragment content="Label">
                                                             <attributes>
@@ -5194,7 +5194,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="noAccidentCell" rowHeight="70" id="K3k-wg-DwN">
-                                        <rect key="frame" x="0.0" y="134" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="130.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="K3k-wg-DwN" id="tLY-bK-CGB">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -5409,7 +5409,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Stats" id="cSo-Xd-4qn">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="statsCell" rowHeight="67" id="Eb3-wj-pd7">
-                                        <rect key="frame" x="0.0" y="203" width="375" height="67"/>
+                                        <rect key="frame" x="0.0" y="197" width="375" height="67"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Eb3-wj-pd7" id="jr5-tY-Qsk">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="67"/>
@@ -5497,7 +5497,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Factors" id="mEE-sW-bJA">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="factorCell" rowHeight="45" id="wk2-ku-R8V">
-                                        <rect key="frame" x="0.0" y="326" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="314" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wk2-ku-R8V" id="fCk-tZ-hmr">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5523,7 +5523,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Injuries" id="KwJ-15-fER">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="injuryCell" rowHeight="45" id="l8a-5B-9mT">
-                                        <rect key="frame" x="0.0" y="427" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="409" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="l8a-5B-9mT" id="Xau-22-LIc">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5549,7 +5549,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="causes" id="zJv-vm-EZf">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="causeCell" rowHeight="45" id="foV-Cm-DfP">
-                                        <rect key="frame" x="0.0" y="528" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="504" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="foV-Cm-DfP" id="Utq-Ae-4Vh">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5575,7 +5575,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Description" id="Rkx-Ib-rli">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="descriptionCell" rowHeight="45" id="WZV-gh-fPn">
-                                        <rect key="frame" x="0.0" y="629" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="599" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WZV-gh-fPn" id="Kxt-m8-thR">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5641,7 +5641,7 @@ Don't worry, you'll be checking levels in no time!</string>
                         <color key="separatorColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="xcv-oT-ggc">
-                            <rect key="frame" x="0.0" y="676" width="375" height="65"/>
+                            <rect key="frame" x="0.0" y="662.00000069358134" width="375" height="65"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bJ-07-V3N">
@@ -5668,7 +5668,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection footerTitle="" id="S9w-MJ-218">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="74" id="Wdx-fC-yLU">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="74"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="74"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Wdx-fC-yLU" id="l3f-Hk-OlX">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="74"/>
@@ -5710,7 +5710,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="" id="mcT-Tv-JzW">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="270" id="0wG-vb-4Ac">
-                                        <rect key="frame" x="0.0" y="158" width="375" height="270"/>
+                                        <rect key="frame" x="0.0" y="147.50000034679067" width="375" height="270"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0wG-vb-4Ac" id="Op9-0h-sVV">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="270"/>
@@ -5780,7 +5780,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="55" id="uDV-aj-Yty">
-                                        <rect key="frame" x="0.0" y="428" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="417.50000034679067" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uDV-aj-Yty" id="qxR-4L-1Nk">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
@@ -5802,7 +5802,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="55" id="B3v-d1-DYe">
-                                        <rect key="frame" x="0.0" y="483" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="472.50000034679067" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="B3v-d1-DYe" id="R0x-ET-Dpa">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
@@ -5879,14 +5879,14 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="55" id="AM8-Ou-TQJ">
-                                        <rect key="frame" x="0.0" y="538" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="527.50000034679067" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AM8-Ou-TQJ" id="4Dy-uI-ARq">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="55"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="55"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Runnable" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rwI-X6-5Ub">
-                                                    <rect key="frame" x="151" y="0.0" width="189" height="55"/>
+                                                    <rect key="frame" x="151" y="0.0" width="190.5" height="55"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                     <color key="textColor" name="primary"/>
                                                     <nil key="highlightedColor"/>
@@ -5913,14 +5913,14 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="55" id="mO8-WE-2J1">
-                                        <rect key="frame" x="0.0" y="593" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="582.50000034679067" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mO8-WE-2J1" id="5V2-Fr-fn5">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="55"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="55"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="July 1, 2020 4:33pm" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QFQ-Nm-LfI">
-                                                    <rect key="frame" x="130" y="0.0" width="210" height="55"/>
+                                                    <rect key="frame" x="130" y="0.0" width="211.5" height="55"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                     <color key="textColor" name="primary"/>
                                                     <nil key="highlightedColor"/>

--- a/American Whitewater/Extensions/UIViewController+Toast.swift
+++ b/American Whitewater/Extensions/UIViewController+Toast.swift
@@ -1,0 +1,23 @@
+import Foundation
+import UIKit
+
+extension UIViewController {
+
+func showToast(message : String, font: UIFont) {
+
+    let toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width/2 - 75, y: self.view.frame.size.height-100, width: 150, height: 35))
+    toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+    toastLabel.textColor = UIColor.white
+    toastLabel.font = font
+    toastLabel.textAlignment = .center;
+    toastLabel.text = message
+    toastLabel.alpha = 1.0
+    toastLabel.layer.cornerRadius = 10;
+    toastLabel.clipsToBounds  =  true
+    self.view.addSubview(toastLabel)
+    UIView.animate(withDuration: 4.0, delay: 0.1, options: .curveEaseOut, animations: {
+         toastLabel.alpha = 0.0
+    }, completion: {(isCompleted) in
+        toastLabel.removeFromSuperview()
+    })
+} }

--- a/American Whitewater/Helpers/AWProgress.swift
+++ b/American Whitewater/Helpers/AWProgress.swift
@@ -13,7 +13,7 @@ class AWProgress {
     
     var progressView = AWProgressView();
     
-    // setup propper singleton
+    // setup proper singleton
     private init() {}
        
     

--- a/American Whitewater/Helpers/DuffekDialog.swift
+++ b/American Whitewater/Helpers/DuffekDialog.swift
@@ -291,6 +291,12 @@ class DuffekDialog {
             rootViewController = tabBarController.selectedViewController
         }
         
+        // Whoops, if there's already a presented view controller this won't work
+        // In that case, it's necessary to present on the presented controller (which can define itself as the 'presentation context', which allows nested modal presentation
+        if let presented = rootViewController?.presentedViewController {
+            rootViewController = presented
+        }
+        
         // Display the chosen view
         rootViewController?.present(alertController, animated: true, completion: nil)
     }

--- a/American Whitewater/Helpers/Location.swift
+++ b/American Whitewater/Helpers/Location.swift
@@ -1,0 +1,46 @@
+import UIKit
+import Foundation
+import CoreLocation
+
+class Location {
+    static let shared = Location()
+    private init() {}
+    
+    // User takes an action that requires location, like clicking on the my location button.
+    func checkLocationStatusOnUserAction(manager: CLLocationManager) -> Bool {
+        if CLLocationManager.authorizationStatus() == .authorizedWhenInUse || CLLocationManager.authorizationStatus() == .authorizedAlways {
+            return true
+        }
+        
+        if CLLocationManager.authorizationStatus() == .denied {
+            showLocationDeniedMessage()
+        } else if CLLocationManager.authorizationStatus() == .notDetermined {
+            manager.requestWhenInUseAuthorization()
+        }
+        return false
+    }
+
+    // App needs location data, but not from a direct user action.
+    func checkLocationStatusInBackground(manager: CLLocationManager) -> Bool {
+        if CLLocationManager.authorizationStatus() == .authorizedWhenInUse || CLLocationManager.authorizationStatus() == .authorizedAlways {
+            return true
+        }
+        
+        if CLLocationManager.authorizationStatus() == .notDetermined {
+            manager.requestWhenInUseAuthorization()
+        }
+        return false
+    }
+
+    func showLocationDeniedMessage() {
+        DuffekDialog.shared.showStandardDialog(title: "Location not enabled", message: "We are unable to use your current location. Please update your settings to use this feature.", buttonTitle: "Change Settings", buttonFunction: {
+            
+            // take user to change their settings
+            if let bundleId = Bundle.main.bundleIdentifier,
+                let url = URL(string: "\(UIApplication.openSettingsURLString)&path=LOCATION/\(bundleId)") {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+            
+        }, cancelFunction: {})
+    }
+}

--- a/American Whitewater/Helpers/Location.swift
+++ b/American Whitewater/Helpers/Location.swift
@@ -9,27 +9,38 @@ class Location {
     
     // User takes an action that requires location, like clicking on the my location button.
     func checkLocationStatusOnUserAction(manager: CLLocationManager) -> Bool {
-        if CLLocationManager.authorizationStatus() == .authorizedWhenInUse || CLLocationManager.authorizationStatus() == .authorizedAlways {
+        switch CLLocationManager.authorizationStatus() {
+        case .authorizedAlways, .authorizedWhenInUse:
             return true
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .denied:
+            showLocationDeniedMessage()
+        case .restricted:
+            // TODO: should this also show the location denied message?
+            // (it indicates that location services aren't available, but probably for circumstances the user can't control)
+            break
+        
+        @unknown default:
+            break
         }
         
-        if CLLocationManager.authorizationStatus() == .denied {
-            showLocationDeniedMessage()
-        } else if CLLocationManager.authorizationStatus() == .notDetermined {
-            manager.requestWhenInUseAuthorization()
-        }
         return false
     }
 
     // App needs location data, but not from a direct user action.
     func checkLocationStatusInBackground(manager: CLLocationManager) -> Bool {
-        if CLLocationManager.authorizationStatus() == .authorizedWhenInUse || CLLocationManager.authorizationStatus() == .authorizedAlways {
+        switch CLLocationManager.authorizationStatus() {
+        case .authorizedWhenInUse, .authorizedAlways:
             return true
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .restricted, .denied:
+            break
+        @unknown default:
+            break
         }
         
-        if CLLocationManager.authorizationStatus() == .notDetermined {
-            manager.requestWhenInUseAuthorization()
-        }
         return false
     }
 

--- a/American Whitewater/Helpers/Location.swift
+++ b/American Whitewater/Helpers/Location.swift
@@ -1,4 +1,5 @@
 import UIKit
+import MapKit
 import Foundation
 import CoreLocation
 
@@ -42,5 +43,10 @@ class Location {
             }
             
         }, cancelFunction: {})
+    }
+    
+    func hasLocation(mapView: MKMapView) -> Bool {
+        return mapView.userLocation.coordinate.latitude != 0 &&
+        mapView.userLocation.coordinate.longitude != 0
     }
 }

--- a/American Whitewater/ViewControllers/Map/MapViewController.swift
+++ b/American Whitewater/ViewControllers/Map/MapViewController.swift
@@ -219,12 +219,8 @@ class MapViewController: UIViewController, MKMapViewDelegate, CLLocationManagerD
     }
     
     func showUserLocation() {
-        if DefaultsManager.showRegionFilter {
-            mapView.showsUserLocation = false
-        } else {
-            mapView.showsUserLocation = true
-            MapViewController.userChangedMap = false
-        }
+        mapView.showsUserLocation = true
+        MapViewController.userChangedMap = false
     }
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
@@ -246,9 +242,14 @@ class MapViewController: UIViewController, MKMapViewDelegate, CLLocationManagerD
     }
     
     @IBAction func showUserLocationPressed(_ sender: Any) {
-        if let mapView = mapView {
-            mapView.showsUserLocation = true
-            mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+        if Location.shared.checkLocationStatusOnUserAction(manager: locationManager) {
+            showUserLocation()
+            
+            if let mapView = mapView {
+                if Location.shared.hasLocation(mapView: mapView) {
+                    mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+                }
+            }
         }
     }
     

--- a/American Whitewater/ViewControllers/OnBoard/OnboardLocationViewController.swift
+++ b/American Whitewater/ViewControllers/OnBoard/OnboardLocationViewController.swift
@@ -24,6 +24,9 @@ class OnboardLocationViewController: UIViewController, CLLocationManagerDelegate
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // This controller is the presentation context for any further modal presentations, like the location denied alert
+        definesPresentationContext = true
 
         // setup style elements
         nextButton.layer.cornerRadius = 22.5
@@ -67,7 +70,6 @@ class OnboardLocationViewController: UIViewController, CLLocationManagerDelegate
             if Location.shared.checkLocationStatusOnUserAction(manager: locationManager) {
                 locationManager.startUpdatingLocation()
             }
-            
         } else if nextButton.titleLabel?.text == "Use Entered Zipcode" {
             
             // Geocode the zip code so we can get the region from the

--- a/American Whitewater/ViewControllers/OnBoard/OnboardLocationViewController.swift
+++ b/American Whitewater/ViewControllers/OnBoard/OnboardLocationViewController.swift
@@ -160,8 +160,6 @@ class OnboardLocationViewController: UIViewController, CLLocationManagerDelegate
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         if status == .authorizedWhenInUse || status == .authorizedAlways {
             locationManager.startUpdatingLocation()
-        } else {
-            Location.shared.showLocationDeniedMessage()
         }
     }
 }

--- a/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
@@ -46,7 +46,7 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
         super.viewDidAppear(animated)
 
         if Location.shared.checkLocationStatusInBackground(manager: locationManager) {
-            locationManager.startUpdatingLocation()
+            showUserLocation()
         }
         
         // setup all map markers/annotation
@@ -191,17 +191,8 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
         
         self.mapView.setVisibleMapRectToFitAllAnnotations(animated: true, shouldIncludeUserAccuracyRange: true, shouldIncludeOverlays: true)
     }
-    
-    
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let location = locations.last {
-            locationManager.stopUpdatingLocation()
-            showUserLocation()
-        }
-    }
-    
+
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        
         if status == .authorizedWhenInUse || status == .authorizedAlways {
             showUserLocation()
         }
@@ -220,7 +211,9 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
             showUserLocation()
             
             if let mapView = mapView {
-                mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+                if Location.shared.hasLocation(mapView: mapView) {
+                    mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+                }
             }
         }
     }


### PR DESCRIPTION
*Outstanding bug: dialog does not show on onboarding screen.*

This PR allows users to use the app without location permissions. Previously, blocking dialogs would appear until the user gave location permissions, even though the app does not require location to function correctly in most situations. This PR also refactors and streamlines location handling. There are two main flows for requesting location:

1. If the user took an action that requires location, like clicking on a button -> shows a dialog if location is disabled
2. If the app needs location in the background -> does not show a dialog if location is disabled

There are 4 places that require location: onboarding, distance filtering, run list map, and run detail map. For the maps, `mapView.showUserLocation` automatically pulls location and shows it, so no further action is required. For the other two situations, we have to use `locationManager.startUpdatingLocation` and use the delegate for location updates. 
