### PR TITLE
Refactor to use toasts, show signin screen once per day, don't populate starting location for directions.

### DIFF
--- a/American Whitewater/Extensions/UIViewController+Toast.swift
+++ b/American Whitewater/Extensions/UIViewController+Toast.swift
@@ -3,12 +3,11 @@ import UIKit
 
 extension UIViewController {
 
-func showToast(message : String, font: UIFont) {
+func showToast(message : String) {
 
     let toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width/2 - 75, y: self.view.frame.size.height-100, width: 150, height: 35))
     toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
     toastLabel.textColor = UIColor.white
-    toastLabel.font = font
     toastLabel.textAlignment = .center;
     toastLabel.text = message
     toastLabel.alpha = 1.0

--- a/American Whitewater/Helpers/DefaultsManager.swift
+++ b/American Whitewater/Helpers/DefaultsManager.swift
@@ -269,6 +269,16 @@ class DefaultsManager {
         }
     }
     
+    private static let signInLastShownKey = "signInLastShownKey"
+    static var signInLastShown: Date? {
+        get {
+            return UserDefaults.standard.object(forKey: signInLastShownKey) as? Date
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: signInLastShownKey)
+        }
+    }
+    
     // for now we'll store all the users favorites in the preferences
     // eventually we'll move it back over to CoreData
     private static let userFavoritesKey = "userFavoritesKey"

--- a/American Whitewater/Helpers/GraphQL/AWGQLArticleApiHelper.swift
+++ b/American Whitewater/Helpers/GraphQL/AWGQLArticleApiHelper.swift
@@ -112,8 +112,7 @@ class AWGQLArticleApiHelper
 
         } errorCallback: { (error, errorMessage) in
             print("Error with fetching news articles: \(error?.localizedDescription ?? errorMessage ?? "No error message available")")
-            let errorMessage = GQLError.handleGQLError(error: error, altMessage: errorMessage)
-            DuffekDialog.shared.showOkDialog(title: "Connection Issue", message: "We were unable to connect to the server due to: \(errorMessage)")
+            errorCallback(error) // AWTODO is this correct?
         }
     }
 }

--- a/American Whitewater/Helpers/Location.swift
+++ b/American Whitewater/Helpers/Location.swift
@@ -50,11 +50,3 @@ class Location {
         mapView.userLocation.coordinate.longitude != 0
     }
 }
-
-// Flow for a map
-// If user has authorized location ->
-    // mapView.showUserLocation -> will automatically start pulling location
-// If not authorized -> request if appropriate
-    // If request authorized -> goes to didChangeAuthorization delegate
-    // mapView.showUserLocation -> will automatically start pulling location
-// Else do nothing

--- a/American Whitewater/Helpers/Location.swift
+++ b/American Whitewater/Helpers/Location.swift
@@ -1,4 +1,5 @@
 import UIKit
+import MapKit
 import Foundation
 import CoreLocation
 
@@ -43,4 +44,17 @@ class Location {
             
         }, cancelFunction: {})
     }
+    
+    func hasLocation(mapView: MKMapView) -> Bool {
+        return mapView.userLocation.coordinate.latitude != 0 &&
+        mapView.userLocation.coordinate.longitude != 0
+    }
 }
+
+// Flow for a map
+// If user has authorized location ->
+    // mapView.showUserLocation -> will automatically start pulling location
+// If not authorized -> request if appropriate
+    // If request authorized -> goes to didChangeAuthorization delegate
+    // mapView.showUserLocation -> will automatically start pulling location
+// Else do nothing

--- a/American Whitewater/ViewControllers/Favorites/FavoritesViewController.swift
+++ b/American Whitewater/ViewControllers/Favorites/FavoritesViewController.swift
@@ -81,7 +81,7 @@ class FavoritesViewController: UIViewController {
         } catch {
             let error = error as NSError
             print("Error fetching favorites from core data: \(error), \(error.userInfo)")
-            DuffekDialog.shared.showOkDialog(title: "Connection Error", message: error.userInfo.description)
+            self.showToast(message: "Connection Error: " + error.userInfo.description)
         }
     }
 

--- a/American Whitewater/ViewControllers/Map/MapViewController.swift
+++ b/American Whitewater/ViewControllers/Map/MapViewController.swift
@@ -140,7 +140,7 @@ class MapViewController: UIViewController, MKMapViewDelegate, CLLocationManagerD
         } catch {
             let error = error as NSError
             print("Error fetching reaches for map: \(error), \(error.userInfo)")
-            DuffekDialog.shared.showOkDialog(title: "Connection Error", message: error.userInfo.description)
+            self.showToast(message: "Connection Error: " + error.userInfo.description)
         }
         
         // add the reaches from core data to the map

--- a/American Whitewater/ViewControllers/Map/MapViewController.swift
+++ b/American Whitewater/ViewControllers/Map/MapViewController.swift
@@ -219,12 +219,8 @@ class MapViewController: UIViewController, MKMapViewDelegate, CLLocationManagerD
     }
     
     func showUserLocation() {
-        if DefaultsManager.showRegionFilter {
-            mapView.showsUserLocation = false
-        } else {
-            mapView.showsUserLocation = true
-            MapViewController.userChangedMap = false
-        }
+        mapView.showsUserLocation = true
+        MapViewController.userChangedMap = false
     }
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
@@ -246,9 +242,14 @@ class MapViewController: UIViewController, MKMapViewDelegate, CLLocationManagerD
     }
     
     @IBAction func showUserLocationPressed(_ sender: Any) {
-        if let mapView = mapView {
-            mapView.showsUserLocation = true
-            mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+        if Location.shared.checkLocationStatusOnUserAction(manager: locationManager) {
+            showUserLocation()
+            
+            if let mapView = mapView {
+                if Location.shared.hasLocation(mapView: mapView) {
+                    mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+                }
+            }
         }
     }
     

--- a/American Whitewater/ViewControllers/More/MoreTableViewController.swift
+++ b/American Whitewater/ViewControllers/More/MoreTableViewController.swift
@@ -75,7 +75,6 @@ class MoreTableViewController: UITableViewController, MFMailComposeViewControlle
                 present(mail, animated: true)
             
             } else {
-               // show failure alert
                 DuffekDialog.shared.showOkDialog(title: "Feedback Issue ", message: "Please setup a valid email account before attempting to contact us.")
             }
         } else if indexPath.row == 4 {
@@ -118,9 +117,9 @@ class MoreTableViewController: UITableViewController, MFMailComposeViewControlle
         
         switch result {
             case .sent:
-                DuffekDialog.shared.showOkDialog(title: "Success", message: "Thanks for your feedback!")
+                self.showToast(message: "Thanks for your feedback!")
             case .failed:
-                DuffekDialog.shared.showOkDialog(title: "Sending Failed", message: "We were unable to send the message. Please check your connection and try again.")
+                self.showToast(message: "We were unable to send the message. Please check your connection and try again.")
             default:
                 break
         }

--- a/American Whitewater/ViewControllers/News/NewsTableViewController.swift
+++ b/American Whitewater/ViewControllers/News/NewsTableViewController.swift
@@ -79,7 +79,7 @@ class NewsTableViewController: UITableViewController {
             var message = "Unknown Reason"
             if let error = error { message = error.localizedDescription }
             print("Error updating articles: \(message)")
-            DuffekDialog.shared.showOkDialog(title: "Connection Error", message: message)
+            self.showToast(message: "Connection Error: " + message)
         }
     }
     
@@ -103,7 +103,7 @@ class NewsTableViewController: UITableViewController {
         } catch {
             let error = error as NSError
             print("Error fetching articles from coredata: \(error), \(error.userInfo)")
-            DuffekDialog.shared.showOkDialog(title: "Connection Error", message: error.userInfo.description)
+            self.showToast(message: "Connection Error: " + error.userInfo.description)
         }
     }
     

--- a/American Whitewater/ViewControllers/OnBoard/OnboardLocationViewController.swift
+++ b/American Whitewater/ViewControllers/OnBoard/OnboardLocationViewController.swift
@@ -28,6 +28,7 @@ class OnboardLocationViewController: UIViewController, CLLocationManagerDelegate
         // setup style elements
         nextButton.layer.cornerRadius = 22.5
         
+        // For presenting dialogs
         self.locationManager.delegate = self
     }
     

--- a/American Whitewater/ViewControllers/OnBoard/SignInViewController.swift
+++ b/American Whitewater/ViewControllers/OnBoard/SignInViewController.swift
@@ -18,12 +18,11 @@ class SignInViewController: UIViewController {
         // Do any additional setup after loading the view.
         signInButton.layer.cornerRadius = 22.5
         createAccountButton.layer.cornerRadius = 22.5
+        
+        DefaultsManager.signInLastShown = Date()
     }
     
     @IBAction func cancelButtonPressed(_ sender: Any) {
-        
-        let count = DefaultsManager.signInAlertCount
-        DefaultsManager.signInAlertCount = count + 1
         
         // close the modal view
         self.dismiss(animated: true, completion: nil)

--- a/American Whitewater/ViewControllers/Reaches/AlertsViewControllers/AddAlertTableViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/AlertsViewControllers/AddAlertTableViewController.swift
@@ -86,18 +86,16 @@ class AddAlertTableViewController: UITableViewController {
             AWProgressModal.shared.hideWith {
                 let errorMessage = GQLError.handleGQLError(error: error, altMessage: message)
                 print("Error:", errorMessage)
-                DuffekDialog.shared.showOkDialog(title: "Connection Issue", message: "We were unable to connect to the server due to: \(errorMessage)")
+                self.showToast(message: "Connection error: \(errorMessage)")
             }
         }
     }
 
     
     func successAndDismissView() {
-        DuffekDialog.shared.showOkDialog(title: "Alert Posted", message: "Your alert has been added. Thank you for providing valuable information to the river community.\n\nRiver Karma Granted!") {
-            //self.navigationController?.popViewController(animated: true)
-            DispatchQueue.main.async {
-                self.navigationController?.popViewController(animated: true)
-            }
+        self.showToast(message: "Your alert has been added. Thank you for providing valuable information to the river community.\n\nRiver Karma Granted!")
+        DispatchQueue.main.async {
+            self.navigationController?.popViewController(animated: true)
         }
     }
     

--- a/American Whitewater/ViewControllers/Reaches/GalleryViewControllers/ReviewPhotoTableViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/GalleryViewControllers/ReviewPhotoTableViewController.swift
@@ -95,37 +95,36 @@ class ReviewPhotoTableViewController: UITableViewController {
                 print("Photo uploaded - callback returned")
                 
                 if let imageResult = photoFileUpdate.image, let uri = imageResult.uri {
-                    DuffekDialog.shared.showOkDialog(title: "Photo Saved", message: "Your photo has been successfully saved.") {
-                        if let _ = self.senderVC {
-                            var newUri = [String:String?]()
-                            newUri["thumb"] = uri.thumb
-                            newUri["med"] = uri.medium
-                            newUri["big"] = uri.big
-                            newUri["caption"] = self.captionTextField.text ?? ""
-                            if let description = self.descriptionTextView.text {
-                                newUri["description"] = description
-                            }
-                            newUri["author"] = "You"
-                            newUri["photoDate"] = self.approxDateTimeLabel.text ?? ""
-                            if let observed = self.addObservationLabel.text {
-                                if observed != self.OBSERVED_PLACEHOLDER {
-                                    newUri["observed"] = observed
-                                }
-                            }
-                            
-                            self.senderVC?.imageLinks.insert(newUri, at: 0)
+                    self.showToast(message: "Your photo has been successfully saved.")
+                    if let _ = self.senderVC {
+                        var newUri = [String:String?]()
+                        newUri["thumb"] = uri.thumb
+                        newUri["med"] = uri.medium
+                        newUri["big"] = uri.big
+                        newUri["caption"] = self.captionTextField.text ?? ""
+                        if let description = self.descriptionTextView.text {
+                            newUri["description"] = description
                         }
-
-                        self.navigationController?.popViewController(animated: true)
+                        newUri["author"] = "You"
+                        newUri["photoDate"] = self.approxDateTimeLabel.text ?? ""
+                        if let observed = self.addObservationLabel.text {
+                            if observed != self.OBSERVED_PLACEHOLDER {
+                                newUri["observed"] = observed
+                            }
+                        }
+                        
+                        self.senderVC?.imageLinks.insert(newUri, at: 0)
                     }
+
+                    self.navigationController?.popViewController(animated: true)
                 } else {
-                    DuffekDialog.shared.showOkDialog(title: "Upload Issue", message: "We were unable to save your photo to the server. Please try again or try another photo.")
+                    self.showToast(message: "We were unable to save your photo to the server. Please try again or try another photo.")
                 }                
                 
             }) { (error, message) in
                 AWProgressModal.shared.hide()
                 print("Error: \(error?.localizedDescription ?? "no error object") -- \(message ?? "no message")")
-                DuffekDialog.shared.showOkDialog(title: "An Error Occured", message: "\(error?.localizedDescription ?? "")\n\(message ?? "")")
+                self.showToast(message: "An Error Occured: \(error?.localizedDescription ?? "")\n\(message ?? "")")
             }
         }
     }

--- a/American Whitewater/ViewControllers/Reaches/RiverFlowControllers/AddRiverFlowTableViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RiverFlowControllers/AddRiverFlowTableViewController.swift
@@ -80,7 +80,6 @@ class AddRiverFlowTableViewController: UITableViewController {
     }
     
     @IBAction func submitFlowButtonPressed(_ sender: Any) {
-        //DuffekDialog.shared.showOkDialog(title: "Feature Coming", message: "This feature is being updated and will be available in the next release.")
         observedGaugeLevelTextField.resignFirstResponder()
         observationTitleTextField.resignFirstResponder()
         
@@ -129,9 +128,8 @@ class AddRiverFlowTableViewController: UITableViewController {
                 print("Flow Posted: \(postResult.title ?? "no title") -- \(postResult.postDate ?? "no date")")
             }
             
-            DuffekDialog.shared.showOkDialog(title: "Flow Saved", message: "Your flow observation has been reported and saved.") {
-                self.navigationController?.popViewController(animated: true)
-            }
+            self.showToast(message: "Your flow observation has been reported and saved.")
+            self.navigationController?.popViewController(animated: true)
             
         }) { (error, errorMessage) in
             AWProgressModal.shared.hide()
@@ -158,35 +156,34 @@ class AddRiverFlowTableViewController: UITableViewController {
             print("Photo uploaded - callback returned")
             
             if let imageResult = photoFileUpdate.image, let uri = imageResult.uri {
-                DuffekDialog.shared.showOkDialog(title: "Flow Saved", message: "Your flow observation has been reported and saved.") {
-                    if let _ = self.senderVC {
-                        var newFlow = [String:String?]()
-                        newFlow["thumb"] = uri.thumb
-                        newFlow["med"] = uri.medium
-                        newFlow["big"] = uri.big
-                        
-                        newFlow["id"] = "\(photoPostUpdate.id ?? photoFileUpdate.id)"
-                        newFlow["title"] = photoFileUpdate.caption ?? photoPostUpdate.title ?? ""
-                        newFlow["description"] = photoFileUpdate.description ?? photoPostUpdate.detail ?? ""
-                        newFlow["reading"] = "\(photoPostUpdate.reading != nil ? "\(photoPostUpdate.reading!)" : "n/a")"
-                        newFlow["author"] = photoFileUpdate.author ?? photoPostUpdate.user?.uname ?? "You"
-                        newFlow["postDate"] = photoFileUpdate.photoDate ?? photoPostUpdate.postDate ?? ""
-                        newFlow["metric"] = photoPostUpdate.metric?.unit ?? ""
-                        // TODO: newFlow["observed"] = ????
-                        
-                        self.senderVC?.riverFlows.insert(newFlow, at: 0)
-                    }
-
-                    self.navigationController?.popViewController(animated: true)
+                self.showToast(message: "Your flow observation has been reported and saved.")
+                if let _ = self.senderVC {
+                    var newFlow = [String:String?]()
+                    newFlow["thumb"] = uri.thumb
+                    newFlow["med"] = uri.medium
+                    newFlow["big"] = uri.big
+                    
+                    newFlow["id"] = "\(photoPostUpdate.id ?? photoFileUpdate.id)"
+                    newFlow["title"] = photoFileUpdate.caption ?? photoPostUpdate.title ?? ""
+                    newFlow["description"] = photoFileUpdate.description ?? photoPostUpdate.detail ?? ""
+                    newFlow["reading"] = "\(photoPostUpdate.reading != nil ? "\(photoPostUpdate.reading!)" : "n/a")"
+                    newFlow["author"] = photoFileUpdate.author ?? photoPostUpdate.user?.uname ?? "You"
+                    newFlow["postDate"] = photoFileUpdate.photoDate ?? photoPostUpdate.postDate ?? ""
+                    newFlow["metric"] = photoPostUpdate.metric?.unit ?? ""
+                    // TODO: newFlow["observed"] = ????
+                    
+                    self.senderVC?.riverFlows.insert(newFlow, at: 0)
                 }
+
+                self.navigationController?.popViewController(animated: true)
             } else {
-                DuffekDialog.shared.showOkDialog(title: "Upload Issue", message: "We were unable to save your flow report to the server. Please check your connection and try again.")
+                self.showToast(message: "We were unable to save your flow report to the server. Please check your connection and try again.")
             }
             
         }) { (error, message) in
             AWProgressModal.shared.hide()
             print("Error: \(error?.localizedDescription ?? "no error object") -- \(message ?? "no message")")
-            DuffekDialog.shared.showOkDialog(title: "An Error Occured", message: "\(error?.localizedDescription ?? "")\n\(message ?? "")")
+            self.showToast(message: "An Error Occured: \(error?.localizedDescription ?? "")\n\(message ?? "")")
         }
     }
     

--- a/American Whitewater/ViewControllers/Reaches/RiverFlowControllers/RiverFlowsViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RiverFlowControllers/RiverFlowsViewController.swift
@@ -264,7 +264,7 @@ extension RiverFlowsViewController: UITableViewDataSource, UITableViewDelegate {
             let imagePath = "\(AWGC.AW_BASE_URL)\(imageLink)"
             
             if !imagePath.contains("https://") && !imagePath.contains("http://") {
-                DuffekDialog.shared.showOkDialog(title: errorTitle, message: errorMessage)
+                self.showToast(message: "Connection Error: " + errorMessage)
                 print("imagePath issue: ", imagePath)
                 return
             }
@@ -274,7 +274,7 @@ extension RiverFlowsViewController: UITableViewDataSource, UITableViewDelegate {
                 let vc = SFSafariViewController(url: url, configuration: config)
                 present(vc, animated: true)
             } else {
-                DuffekDialog.shared.showOkDialog(title: errorTitle, message: errorMessage)
+                self.showToast(message: errorTitle + " " + errorMessage)
                 print("imagePath issue: ", imagePath)
             }
         }

--- a/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
@@ -140,7 +140,7 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
                 
                 DuffekDialog.shared.showStandardDialog(title: "Open in Maps?", message: "Would you like directions to the \(annotation.title ?? "River")", buttonTitle: "Get Directions", buttonFunction: {
                     // take them to Apple Maps
-                    let url = "http://maps.apple.com/maps?saddr=\(DefaultsManager.latitude),\(DefaultsManager.longitude)&daddr=\(annotation.coordinate.latitude),\(annotation.coordinate.longitude)"
+                    let url = "http://maps.apple.com/maps?daddr=\(annotation.coordinate.latitude),\(annotation.coordinate.longitude)"
                     UIApplication.shared.open(URL(string: url)!, options: [:], completionHandler: nil)
 
                 }, cancelFunction: {

--- a/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
@@ -46,7 +46,7 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
         super.viewDidAppear(animated)
 
         if Location.shared.checkLocationStatusInBackground(manager: locationManager) {
-            locationManager.startUpdatingLocation()
+            showUserLocation()
         }
         
         // setup all map markers/annotation
@@ -191,17 +191,8 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
         
         self.mapView.setVisibleMapRectToFitAllAnnotations(animated: true, shouldIncludeUserAccuracyRange: true, shouldIncludeOverlays: true)
     }
-    
-    
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let location = locations.last {
-            locationManager.stopUpdatingLocation()
-            showUserLocation()
-        }
-    }
-    
+
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        
         if status == .authorizedWhenInUse || status == .authorizedAlways {
             showUserLocation()
         }
@@ -220,7 +211,9 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
             showUserLocation()
             
             if let mapView = mapView {
-                mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+                if Location.shared.hasLocation(mapView: mapView) {
+                    mapView.setCenter(mapView.userLocation.coordinate, animated: true)
+                }
             }
         }
     }

--- a/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunMapViewController.swift
@@ -132,7 +132,6 @@ class RunMapViewController: UIViewController, MKMapViewDelegate, CLLocationManag
     // User Clicked on the info of a callout
     func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
         
-        //DuffekDialog.shared.showOkDialog(title: "Rapid Info", message: "Info coming soon...")
         if let annotation = view.annotation as? RunMapAnnotation {
 
             // check if put in or take out, if so open in apple maps (ask first?)

--- a/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
@@ -133,22 +133,6 @@ class RunsListViewController: UIViewController {
         }
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-// ### TestFlight - What's New View ###
-// We use this for TestFlight testing to highlight what has changed
-// if we design it better we can include it in the main app
-//        if (DefaultsManager.whatsNew == nil || DefaultsManager.whatsNew != "whatsNew\(DefaultsManager.appVersion ?? -1)") {
-//            let storyboard = UIStoryboard(name: "Main", bundle: nil)
-//            let newVC = storyboard.instantiateViewController(withIdentifier: "WhatsNewView") as? WhatsNewViewController
-//            if let newVC = newVC {
-//                self.present(newVC, animated: true, completion: nil)
-//            }
-//        }
-    }
-
-    
     func fetchRiversFromCoreData() {
         
         print("Fetching rivers from core data")
@@ -222,21 +206,18 @@ class RunsListViewController: UIViewController {
         return false
     }
 
-/* Debug Screen Only */
     func showLoginScreen() {
-        let count = DefaultsManager.signInAlertCount
-        if count % 5 == 0 {
-            if let modalSignInVC = self.storyboard?.instantiateViewController(withIdentifier: "ModalOnboardLogin") as? SignInViewController {
-                modalSignInVC.modalPresentationStyle = .overCurrentContext
-                modalSignInVC.referenceViewController = self
-                tabBarController?.present(modalSignInVC, animated: true, completion: nil)
+        if let lastShown = DefaultsManager.signInLastShown {
+            // Only show once per day
+            if lastShown < Date(timeIntervalSinceNow: -24 * 60 * 60) {
+                if let modalSignInVC = self.storyboard?.instantiateViewController(withIdentifier: "ModalOnboardLogin") as? SignInViewController {
+                    modalSignInVC.modalPresentationStyle = .overCurrentContext
+                    modalSignInVC.referenceViewController = self
+                    tabBarController?.present(modalSignInVC, animated: true, completion: nil)
+                }
             }
-
-        } else {
-            DefaultsManager.signInAlertCount = count + 1
         }
     }
-    
     
     func refresh(regions: [Region] = Region.all) {
         print("Refresh called")

--- a/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
@@ -183,7 +183,7 @@ class RunsListViewController: UIViewController {
         } catch {
             let error = error as NSError
             print("Error fetching reaches from CoreData: \(error), \(error.userInfo)")
-            DuffekDialog.shared.showOkDialog(title: "Connection Error", message: error.userInfo.description)
+            self.showToast(message: "Connection Error: " + error.userInfo.description)
         }
         
         tableView.reloadData()
@@ -312,7 +312,7 @@ class RunsListViewController: UIViewController {
         } catch {
             let error = error as NSError
             print("Error fetching reaches from coredata: \(error), \(error.userInfo)")
-            DuffekDialog.shared.showOkDialog(title: "Connection Error", message: error.userInfo.description)
+            self.showToast(message: "Connection Error: " + error.userInfo.description)
         }
 
         tableView.reloadData() 
@@ -333,10 +333,9 @@ class RunsListViewController: UIViewController {
                 
                 if let error = error {
                     print("1 Error updating reaches: \(error.localizedDescription)")
-                    DuffekDialog.shared.showOkDialog(title: "Connection Error", message: error.localizedDescription)
+                    self.showToast(message: "Connection Error: " + error.localizedDescription)
                 } else {
                     print("Error updating reaches: Unknown why 2")
-                    //DuffekDialog.shared.showOkDialog(title: "Connection Error", message: "Unknown Reason")
                 }
             }
         }
@@ -367,10 +366,9 @@ class RunsListViewController: UIViewController {
             
             if let error = error {
                 print("2 Error updating reaches: \(error.localizedDescription)")
-                DuffekDialog.shared.showOkDialog(title: "Connection Error", message: error.localizedDescription)
+                self.showToast(message: "Connection Error: " + error.localizedDescription)
             } else {
                 print("Error updating reaches: Unknown why")
-                //DuffekDialog.shared.showOkDialog(title: "Connection Error", message: "Unknown Reason")
             }
         }
 


### PR DESCRIPTION
This PR refactors the app to use toasts instead of the `okDialog` in most situations. The general philosophy here is that the user should not be interrupted unless there is a specific action they are required to take, or they need a piece of information that is critical. Otherwise, a toast should be shown. 

Fixes: https://github.com/AmericanWhitewater/aw-ios/issues/201, https://github.com/AmericanWhitewater/aw-ios/issues/202