### PR TITLE
A caption is not required to post a photo

### DIFF
--- a/American Whitewater/ViewControllers/Reaches/GalleryViewControllers/ReviewPhotoTableViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/GalleryViewControllers/ReviewPhotoTableViewController.swift
@@ -65,12 +65,6 @@ class ReviewPhotoTableViewController: UITableViewController {
 
     
     @IBAction func saveButtonPressed(_ sender: Any) {
-        
-        if captionTextField.text?.count == 0 || captionTextField.text == CAPTION_PLACEHOLDER {
-            DuffekDialog.shared.showOkDialog(title: "Caption Required", message: "Please enter a valid caption before saving your photo.")
-            return
-        }
-        
         if let image = takenImage, let selectedRun = selectedRun, let capText = captionTextField.text {
             
             var description = ""


### PR DESCRIPTION
Looks like there was another place this was getting checked. Fixes #198
