### PR TITLE
Refactor filters

### DIFF
--- a/American Whitewater.xcodeproj/project.pbxproj
+++ b/American Whitewater.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2FE342D026A2846100352D1E /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE342CF26A2846100352D1E /* Location.swift */; };
 		4760DD5C0E5548BBA92D25AF /* Pods_American_Whitewater.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A750E2F24748D3B54A1DEB84 /* Pods_American_Whitewater.framework */; };
 		4A36D1E726A6749E00C85B79 /* UIImagePickerController+FullResolutionEditedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A36D1E626A6749E00C85B79 /* UIImagePickerController+FullResolutionEditedImage.swift */; };
+		4AA3FEFB26B2725100AC4303 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA3FEFA26B2725100AC4303 /* Filters.swift */; };
 		4AC4BB5A26A0F5B50058D8B7 /* NewsArticle+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4BB5826A0F5B50058D8B7 /* NewsArticle+CoreDataClass.swift */; };
 		4AC4BB5B26A0F5B50058D8B7 /* NewsArticle+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4BB5926A0F5B50058D8B7 /* NewsArticle+CoreDataProperties.swift */; };
 		4ADE944D26B0A8D6004D498D /* CLLocationCoordinate2D+difference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADE944C26B0A8D6004D498D /* CLLocationCoordinate2D+difference.swift */; };
@@ -155,6 +156,7 @@
 		2FE342CD26A1FF8100352D1E /* UIViewController+Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Toast.swift"; sourceTree = "<group>"; };
 		2FE342CF26A2846100352D1E /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		4A36D1E626A6749E00C85B79 /* UIImagePickerController+FullResolutionEditedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImagePickerController+FullResolutionEditedImage.swift"; sourceTree = "<group>"; };
+		4AA3FEFA26B2725100AC4303 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
 		4AC4BB5826A0F5B50058D8B7 /* NewsArticle+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NewsArticle+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4AC4BB5926A0F5B50058D8B7 /* NewsArticle+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NewsArticle+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		4ADE944C26B0A8D6004D498D /* CLLocationCoordinate2D+difference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+difference.swift"; sourceTree = "<group>"; };
@@ -598,6 +600,7 @@
 			isa = PBXGroup;
 			children = (
 				63E90EAC22EAA14700C8DAA3 /* DefaultsManager.swift */,
+				4AA3FEFA26B2725100AC4303 /* Filters.swift */,
 				63B5B4982457AE800062F54B /* GraphQL */,
 				63A6FD682367730C00148231 /* AWApiReachHelper.swift */,
 				63A6FD662363EEA200148231 /* AWApiArticleHelper.swift */,
@@ -937,6 +940,7 @@
 				63A6FD672363EEA200148231 /* AWApiArticleHelper.swift in Sources */,
 				631EFFAB23688A3600BA17F7 /* Reach+CoreDataProperties.swift in Sources */,
 				63E90EAD22EAA14700C8DAA3 /* DefaultsManager.swift in Sources */,
+				4AA3FEFB26B2725100AC4303 /* Filters.swift in Sources */,
 				6342A3EB2385AD3500B54365 /* MKMapView+FitAnnotations.swift in Sources */,
 				63DEE01F24ABB3EC00638E84 /* RiverFlowCell.swift in Sources */,
 				63D7BD1923199D1900935693 /* DuffekDialog.swift in Sources */,

--- a/American Whitewater/AppDelegate.swift
+++ b/American Whitewater/AppDelegate.swift
@@ -53,10 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // setting first values for first run
         if !DefaultsManager.shared.completedFirstRun {
-            DefaultsManager.shared.showRegionFilter = true
-            DefaultsManager.shared.showDistanceFilter = false
-            DefaultsManager.shared.distanceFilter = 100
-            DefaultsManager.shared.classFilter = [1,2,3,4,5]
+            DefaultsManager.shared.filters = Filters.defaultByRegionFilters
         }
         
         // make Status Bar white

--- a/American Whitewater/Base.lproj/Main.storyboard
+++ b/American Whitewater/Base.lproj/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19142.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DZd-kw-GNv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="DZd-kw-GNv">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19129"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19134"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -317,13 +318,13 @@
                             </constraints>
                         </view>
                         <view key="tableFooterView" contentMode="scaleToFill" id="adP-ni-F3Z">
-                            <rect key="frame" x="0.0" y="701" width="375" height="1"/>
+                            <rect key="frame" x="0.0" y="690.00000076293941" width="375" height="1"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="NewsCell" rowHeight="109" id="i2j-JX-ehV" customClass="NewsTableViewCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="284" width="375" height="109"/>
+                                <rect key="frame" x="0.0" y="278.5" width="375" height="109"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i2j-JX-ehV" id="gUo-G9-1XA">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
@@ -368,7 +369,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="NewsCell2" rowHeight="280" id="GRx-sZ-whH" customClass="NewsTableViewCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="393" width="375" height="280"/>
+                                <rect key="frame" x="0.0" y="387.5" width="375" height="280"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GRx-sZ-whH" id="6PJ-P7-rQC">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="280"/>
@@ -417,7 +418,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Nu2-he-lYT">
-                                            <rect key="frame" x="348" y="185" width="11" height="37"/>
+                                            <rect key="frame" x="348" y="184.5" width="11" height="37"/>
                                             <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="11" id="27f-g5-Wss"/>
@@ -484,7 +485,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="w3y-SK-HwH">
-                            <rect key="frame" x="0.0" y="485" width="375" height="65"/>
+                            <rect key="frame" x="0.0" y="463.00000152587882" width="375" height="65"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KV6-xY-22y">
@@ -511,7 +512,7 @@
                             <tableViewSection id="o55-rw-a6m">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="titleCell" rowHeight="74" id="qpm-he-uYF">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="74"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="74"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qpm-he-uYF" id="7aB-mb-ZYo">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="74"/>
@@ -549,7 +550,7 @@
                             <tableViewSection headerTitle="" id="4PM-HH-d3f">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="MUN-9v-VVl" detailTextLabel="AVZ-Wb-BV0" rowHeight="54" style="IBUITableViewCellStyleSubtitle" id="pjy-V2-p1g">
-                                        <rect key="frame" x="0.0" y="202" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="185.50000076293946" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pjy-V2-p1g" id="pUc-eg-zfE">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
@@ -573,7 +574,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="201" id="fpF-FA-UjH">
-                                        <rect key="frame" x="0.0" y="256" width="375" height="201"/>
+                                        <rect key="frame" x="0.0" y="239.50000076293946" width="375" height="201"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fpF-FA-UjH" id="HDy-Aa-XJ5">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="201"/>
@@ -736,7 +737,7 @@
                         <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GageDetailOverviewCell" rowHeight="120" id="hTp-A1-Dmm" customClass="GageDetailsCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="50" width="375" height="120"/>
+                                <rect key="frame" x="0.0" y="44.5" width="375" height="120"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hTp-A1-Dmm" id="ePj-uw-fJB">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -825,7 +826,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GageGraphCell" rowHeight="317" id="yUD-YH-cwX" customClass="GageGraphCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="170" width="375" height="317"/>
+                                <rect key="frame" x="0.0" y="164.5" width="375" height="317"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yUD-YH-cwX" id="z1Q-eg-HGP">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="317"/>
@@ -862,7 +863,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="GageForRunCell" rowHeight="80" id="Mxm-rW-RFG" customClass="GageForRunCell" customModule="AW" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="487" width="375" height="80"/>
+                                <rect key="frame" x="0.0" y="481.5" width="375" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Mxm-rW-RFG" id="538-Tq-CKS">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="80"/>
@@ -920,7 +921,7 @@
                             <tableViewSection headerTitle="" id="cpm-Cm-DvA">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="106" id="Cyp-lH-ZB5">
-                                        <rect key="frame" x="0.0" y="39.5" width="375" height="106"/>
+                                        <rect key="frame" x="0.0" y="35" width="375" height="106"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Cyp-lH-ZB5" id="EYP-0v-tmR">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="106"/>
@@ -1001,14 +1002,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="45" id="Z4t-E9-JXW">
-                                        <rect key="frame" x="0.0" y="145.5" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="141" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Z4t-E9-JXW" id="toc-he-B9u">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="45"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View and Report Flows" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X7h-re-vQ2">
-                                                    <rect key="frame" x="20" y="0.0" width="328" height="45"/>
+                                                    <rect key="frame" x="20" y="0.0" width="330" height="45"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="45" id="PzU-TV-MhO"/>
                                                     </constraints>
@@ -1033,7 +1034,7 @@
                             <tableViewSection id="0rB-aW-w2b">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="85" id="E1t-b8-ntb">
-                                        <rect key="frame" x="0.0" y="226.5" width="375" height="85"/>
+                                        <rect key="frame" x="0.0" y="222" width="375" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="E1t-b8-ntb" id="Tey-VQ-WqQ">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="85"/>
@@ -1109,7 +1110,7 @@
                             <tableViewSection id="SF1-Is-ruz">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="180" id="pmx-e7-EfG">
-                                        <rect key="frame" x="0.0" y="347.5" width="375" height="180"/>
+                                        <rect key="frame" x="0.0" y="343" width="375" height="180"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pmx-e7-EfG" id="qq6-kO-fRk">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="180"/>
@@ -1135,7 +1136,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="67" id="kWt-Fq-ygB">
-                                        <rect key="frame" x="0.0" y="527.5" width="375" height="67"/>
+                                        <rect key="frame" x="0.0" y="523" width="375" height="67"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kWt-Fq-ygB" id="EhN-Ek-jI3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="67"/>
@@ -1174,10 +1175,10 @@
                                         <viewLayoutGuide key="safeArea" id="a6g-IQ-nJ6"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="80" id="evF-Bi-3xR">
-                                        <rect key="frame" x="0.0" y="594.5" width="375" height="80"/>
+                                        <rect key="frame" x="0.0" y="590" width="375" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="evF-Bi-3xR" id="g74-rP-0tM">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="80"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="80"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ojo-oj-UgF">
@@ -1211,7 +1212,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pvg-0G-Nde">
-                                                    <rect key="frame" x="0.0" y="0.0" width="348" height="80"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="350" height="80"/>
                                                     <connections>
                                                         <action selector="photoGalleryButtonPressed:" destination="mFc-ar-6ha" eventType="touchUpInside" id="Hpl-32-q1f"/>
                                                     </connections>
@@ -1243,14 +1244,14 @@
                             <tableViewSection id="y2J-GS-y3L">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="QKo-ec-moN" style="IBUITableViewCellStyleDefault" id="8Z1-pj-GVP">
-                                        <rect key="frame" x="0.0" y="710.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="706" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8Z1-pj-GVP" id="XSk-hk-Mqq">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="358" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="River Alerts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QKo-ec-moN">
-                                                    <rect key="frame" x="8" y="0.0" width="340" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="342" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1260,14 +1261,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="2bY-UZ-skd" style="IBUITableViewCellStyleDefault" id="1sU-VR-4hD">
-                                        <rect key="frame" x="0.0" y="754.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="750" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1sU-VR-4hD" id="jKL-mf-icQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="358" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Accident Reports" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2bY-UZ-skd">
-                                                    <rect key="frame" x="8" y="0.0" width="340" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="342" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1277,14 +1278,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="LvI-wQ-4XB" style="IBUITableViewCellStyleDefault" id="tWV-cy-J3k">
-                                        <rect key="frame" x="0.0" y="798.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="794" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tWV-cy-J3k" id="Qvz-aX-4QS">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="358" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="See Gage Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="LvI-wQ-4XB">
-                                                    <rect key="frame" x="8" y="0.0" width="340" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="342" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1294,14 +1295,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Doc-sb-Abw" style="IBUITableViewCellStyleDefault" id="Sog-aW-2Wq">
-                                        <rect key="frame" x="0.0" y="842.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="838" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Sog-aW-2Wq" id="nHm-tU-cgL">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="358" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Go To Website" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Doc-sb-Abw">
-                                                    <rect key="frame" x="8" y="0.0" width="340" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="342" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1311,14 +1312,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Cmj-0U-b4L" style="IBUITableViewCellStyleDefault" id="Kja-zQ-J6r">
-                                        <rect key="frame" x="0.0" y="886.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="882" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Kja-zQ-J6r" id="DGz-WN-ooK">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="358" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" text="Share" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Cmj-0U-b4L">
-                                                    <rect key="frame" x="8" y="0.0" width="340" height="44"/>
+                                                    <rect key="frame" x="8" y="0.0" width="342" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1401,13 +1402,13 @@
                                 <rect key="frame" x="0.0" y="85" width="375" height="404"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="b3h-Tz-mMT">
-                                    <rect key="frame" x="0.0" y="633" width="375" height="1"/>
+                                    <rect key="frame" x="0.0" y="496.00000076293941" width="375" height="1"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RiverFlowCell" rowHeight="278" id="iEJ-Xn-Naj" customClass="RiverFlowCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="278"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="278"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iEJ-Xn-Naj" id="E6Z-tD-jfd">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="278"/>
@@ -1531,7 +1532,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RiverFlowNoPicCell" rowHeight="107" id="zqw-Fn-I2F" customClass="RiverFlowCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="328" width="375" height="107"/>
+                                        <rect key="frame" x="0.0" y="322.5" width="375" height="107"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zqw-Fn-I2F" id="nfH-RL-V3e">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="107"/>
@@ -1626,7 +1627,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="NoRiverFlowCell" rowHeight="170" id="GV5-nq-tbj">
-                                        <rect key="frame" x="0.0" y="435" width="375" height="170"/>
+                                        <rect key="frame" x="0.0" y="429.5" width="375" height="170"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GV5-nq-tbj" id="h8D-4L-KhG">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="170"/>
@@ -2077,7 +2078,7 @@ Description: n/a</string>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="at8-jU-TA3" userLabel="empty view hack">
-                            <rect key="frame" x="0.0" y="815" width="375" height="1"/>
+                            <rect key="frame" x="0.0" y="793.00000152587882" width="375" height="1"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
@@ -2085,7 +2086,7 @@ Description: n/a</string>
                             <tableViewSection id="CeE-5G-in9">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="250" id="gCH-Dk-CVb">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="250"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="250"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gCH-Dk-CVb" id="171-B5-2go">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="250"/>
@@ -2108,7 +2109,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="74" id="OES-yW-hbt">
-                                        <rect key="frame" x="0.0" y="300" width="375" height="74"/>
+                                        <rect key="frame" x="0.0" y="294.5" width="375" height="74"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OES-yW-hbt" id="u4d-Cq-T7q">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="74"/>
@@ -2150,10 +2151,10 @@ Description: n/a</string>
                             <tableViewSection id="beX-Dh-ogH">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="52" id="PxX-kj-Bog">
-                                        <rect key="frame" x="0.0" y="452" width="375" height="52"/>
+                                        <rect key="frame" x="0.0" y="435.50000076293941" width="375" height="52"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PxX-kj-Bog" id="aLg-Ah-mUf">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="52"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="52"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Approx. Date/Time:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tWd-H6-p31">
@@ -2166,7 +2167,7 @@ Description: n/a</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="09/29/2020 03:20 PM" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ywm-bC-GYG">
-                                                    <rect key="frame" x="142" y="16" width="198" height="21"/>
+                                                    <rect key="frame" x="142" y="16" width="200" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                     <color key="textColor" name="primary"/>
                                                     <nil key="highlightedColor"/>
@@ -2183,10 +2184,10 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="52" id="mDv-IA-zcv">
-                                        <rect key="frame" x="0.0" y="504" width="375" height="52"/>
+                                        <rect key="frame" x="0.0" y="487.50000076293941" width="375" height="52"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mDv-IA-zcv" id="ENn-Ko-Zz4">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="52"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="52"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Level Observation:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gIL-Mf-Nyu">
@@ -2199,7 +2200,7 @@ Description: n/a</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add Observation" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2eZ-hT-tCK">
-                                                    <rect key="frame" x="144" y="16" width="196" height="21"/>
+                                                    <rect key="frame" x="144" y="16" width="198" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                     <color key="textColor" name="primary"/>
                                                     <nil key="highlightedColor"/>
@@ -2216,7 +2217,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="56" id="d9V-lg-7Im">
-                                        <rect key="frame" x="0.0" y="556" width="375" height="56"/>
+                                        <rect key="frame" x="0.0" y="539.50000076293941" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="d9V-lg-7Im" id="g8I-Ud-CSj">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
@@ -2251,7 +2252,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="130" id="BRs-Ls-AQA">
-                                        <rect key="frame" x="0.0" y="612" width="375" height="130"/>
+                                        <rect key="frame" x="0.0" y="595.50000076293941" width="375" height="130"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BRs-Ls-AQA" id="qVx-RL-Tbd">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="130"/>
@@ -2286,7 +2287,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="45" id="TFf-rx-bow">
-                                        <rect key="frame" x="0.0" y="742" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="725.50000076293941" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TFf-rx-bow" id="vst-5H-WgO">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -2412,7 +2413,7 @@ Description: n/a</string>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="alertCell" rowHeight="70" id="VjV-Tw-K3k" customClass="AlertTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VjV-Tw-K3k" id="rXM-P0-w9l">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -2469,7 +2470,7 @@ Description: n/a</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="noAlertCell" rowHeight="70" id="s9b-I5-wy5">
-                                        <rect key="frame" x="0.0" y="120" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="114.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="s9b-I5-wy5" id="5cq-Ak-qa1">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -2491,7 +2492,7 @@ Description: n/a</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="loadingAlertCell" rowHeight="70" id="S0b-KQ-5nn">
-                                        <rect key="frame" x="0.0" y="190" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="184.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="S0b-KQ-5nn" id="tNz-5L-WnO">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -2611,13 +2612,13 @@ Description: n/a</string>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="SPn-8e-k5M">
-                                    <rect key="frame" x="0.0" y="480" width="375" height="1"/>
+                                    <rect key="frame" x="0.0" y="469.00000076293941" width="375" height="1"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RunCell" rowHeight="120" id="uF9-W9-eVy" customClass="RunsListTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="120"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uF9-W9-eVy" id="917-Tu-t0D">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -2710,7 +2711,7 @@ Description: n/a</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="NoRiversCell" rowHeight="162" id="HgA-m3-6hE" customClass="NoRiversTableViewCell" customModule="AW">
-                                        <rect key="frame" x="0.0" y="170" width="375" height="162"/>
+                                        <rect key="frame" x="0.0" y="164.5" width="375" height="162"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HgA-m3-6hE" id="bah-Xf-YWZ">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="162"/>
@@ -2767,7 +2768,7 @@ and check your internet connection.</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="LoadingRiversCell" rowHeight="120" id="0g5-UQ-jQ0" customClass="LoadingRiversCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="332" width="375" height="120"/>
+                                        <rect key="frame" x="0.0" y="326.5" width="375" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0g5-UQ-jQ0" id="QUb-7x-kkS">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -3124,7 +3125,7 @@ and check your internet connection.</string>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="zTT-Se-xoI">
-                            <rect key="frame" x="0.0" y="300.5" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="301" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Q0f-Tk-yCb">
@@ -3149,11 +3150,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="18" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hH3-7h-Vas" id="9ni-QJ-Fq0">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="About American Whitewater" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="33Y-my-bdS">
-                                                    <rect key="frame" x="60" y="0.0" width="280" height="43.5"/>
+                                                    <rect key="frame" x="60" y="0.0" width="282" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3173,11 +3174,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="61.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tpY-OE-MCH" id="53L-mB-C9o">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App Team" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="HXt-rF-1Em">
-                                                    <rect key="frame" x="61" y="0.0" width="279" height="43.5"/>
+                                                    <rect key="frame" x="61" y="0.0" width="281" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3197,11 +3198,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="105" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TxO-gG-ING" id="VKW-A8-gWD">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Rate this App" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="v1b-H4-R8M">
-                                                    <rect key="frame" x="61" y="0.0" width="279" height="43.5"/>
+                                                    <rect key="frame" x="61" y="0.0" width="281" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3218,11 +3219,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="148.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZZO-7h-woe" id="z6x-S8-o3H">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3EA-SE-kuX">
-                                                    <rect key="frame" x="61" y="0.0" width="279" height="43.5"/>
+                                                    <rect key="frame" x="61" y="0.0" width="281" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3239,11 +3240,11 @@ and check your internet connection.</string>
                                         <rect key="frame" x="0.0" y="192" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ShU-Mi-LZO" id="PqJ-OM-xyS">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Donate" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="JXf-qh-Zkn">
-                                                    <rect key="frame" x="60" y="0.0" width="280" height="43.5"/>
+                                                    <rect key="frame" x="60" y="0.0" width="282" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="15"/>
                                                     <color key="textColor" name="font_black"/>
@@ -3257,14 +3258,14 @@ and check your internet connection.</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="mb0-8w-R5d">
-                                        <rect key="frame" x="0.0" y="235.5" width="375" height="47"/>
+                                        <rect key="frame" x="0.0" y="235.5" width="375" height="47.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mb0-8w-R5d" id="6ss-zz-Tt2">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="47"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="47.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign In" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N0g-Nm-CE2">
-                                                    <rect key="frame" x="61" y="11" width="103" height="24"/>
+                                                    <rect key="frame" x="61" y="11" width="103" height="24.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="103" id="Gjd-zq-ZBB"/>
                                                     </constraints>
@@ -3453,7 +3454,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                             <tableViewSection id="0mZ-tW-31Z">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="RNQ-8W-cuC">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RNQ-8W-cuC" id="haZ-zO-G8g">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -3461,7 +3462,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="iP6-kx-cDr">
-                                        <rect key="frame" x="0.0" y="93.5" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="88" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iP6-kx-cDr" id="BFp-c8-hgf">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3518,7 +3519,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="vI5-m4-ssd">
-                                        <rect key="frame" x="0.0" y="191.5" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="186" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vI5-m4-ssd" id="Km2-vO-SMj">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3575,7 +3576,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="nhf-zA-nfd">
-                                        <rect key="frame" x="0.0" y="289.5" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="284" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nhf-zA-nfd" id="jN1-3k-ho3">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3632,7 +3633,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="PNt-EJ-AxU">
-                                        <rect key="frame" x="0.0" y="387.5" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="382" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PNt-EJ-AxU" id="lsV-FW-DbL">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3689,7 +3690,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="PQK-4O-z4F">
-                                        <rect key="frame" x="0.0" y="485.5" width="375" height="98"/>
+                                        <rect key="frame" x="0.0" y="480" width="375" height="98"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PQK-4O-z4F" id="1KJ-wg-yXB">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="98"/>
@@ -3708,7 +3709,7 @@ Individual memberships are crucial to American Whitewater and our goal is to rem
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="689" id="bce-Xo-Na5">
-                                        <rect key="frame" x="0.0" y="583.5" width="375" height="689"/>
+                                        <rect key="frame" x="0.0" y="578" width="375" height="689"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bce-Xo-Na5" id="YCf-LA-bIa">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="689"/>
@@ -3815,13 +3816,13 @@ Special thanks to the following people for making this app a reality:       
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
                                 <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="8fn-bN-bd8">
-                                    <rect key="frame" x="0.0" y="198" width="375" height="1"/>
+                                    <rect key="frame" x="0.0" y="187.00000076293946" width="375" height="1"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="FavRunCell" rowHeight="120" id="len-1w-eIL" customClass="RunsListTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="120"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="len-1w-eIL" id="q1H-xO-u41">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
@@ -4093,7 +4094,7 @@ Special thanks to the following people for making this app a reality:       
                             <tableViewSection headerTitle="" id="SjA-uU-8bv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="59" id="FHG-lM-rg1">
-                                        <rect key="frame" x="0.0" y="39.5" width="375" height="59"/>
+                                        <rect key="frame" x="0.0" y="35" width="375" height="59"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="FHG-lM-rg1" id="qeK-kC-hok">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="59"/>
@@ -4119,7 +4120,7 @@ Special thanks to the following people for making this app a reality:       
                             <tableViewSection id="Y6y-pr-0T5">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="95" id="tvw-07-Zcj">
-                                        <rect key="frame" x="0.0" y="134.5" width="375" height="95"/>
+                                        <rect key="frame" x="0.0" y="130" width="375" height="95"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tvw-07-Zcj" id="XBY-NQ-RPP">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="95"/>
@@ -4161,7 +4162,7 @@ Special thanks to the following people for making this app a reality:       
                             <tableViewSection id="Myr-CQ-j0v">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="85" id="Fc0-nm-CXY">
-                                        <rect key="frame" x="0.0" y="265.5" width="375" height="85"/>
+                                        <rect key="frame" x="0.0" y="261" width="375" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Fc0-nm-CXY" id="HdG-qg-Vc7">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="85"/>
@@ -4304,19 +4305,22 @@ Special thanks to the following people for making this app a reality:       
                                                             <rect key="frame" x="0.0" y="44" width="375" height="45"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Selected Regions:" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g6M-xY-41x">
-                                                                    <rect key="frame" x="15" y="0.0" width="345" height="45"/>
+                                                                    <rect key="frame" x="15" y="0.0" width="330" height="45"/>
                                                                     <fontDescription key="fontDescription" name="OpenSans-SemiBold" family="Open Sans" pointSize="16"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j5T-A1-Xzf">
+                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j5T-A1-Xzf">
                                                                     <rect key="frame" x="345" y="0.0" width="30" height="39"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="39" id="Oeo-62-4D4"/>
                                                                         <constraint firstAttribute="width" constant="30" id="sno-xT-w4w"/>
                                                                     </constraints>
-                                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
-                                                                    <state key="normal" title="X"/>
+                                                                    <color key="tintColor" name="font_black"/>
+                                                                    <state key="normal" title="X">
+                                                                        <imageReference key="image" image="xmark.circle" catalog="system" symbolScale="large"/>
+                                                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" weight="semibold"/>
+                                                                    </state>
                                                                 </button>
                                                             </subviews>
                                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -4324,10 +4328,10 @@ Special thanks to the following people for making this app a reality:       
                                                                 <constraint firstAttribute="trailing" secondItem="j5T-A1-Xzf" secondAttribute="trailing" id="2yy-82-flP"/>
                                                                 <constraint firstItem="g6M-xY-41x" firstAttribute="leading" secondItem="sYm-um-Ih5" secondAttribute="leading" constant="15" id="5B7-Kc-87R"/>
                                                                 <constraint firstAttribute="height" secondItem="g6M-xY-41x" secondAttribute="height" id="D0b-h0-Dfy"/>
-                                                                <constraint firstAttribute="trailing" secondItem="g6M-xY-41x" secondAttribute="trailing" constant="15" id="Ot2-j0-kqG"/>
                                                                 <constraint firstItem="g6M-xY-41x" firstAttribute="top" secondItem="sYm-um-Ih5" secondAttribute="top" id="XjN-Jf-998"/>
                                                                 <constraint firstItem="j5T-A1-Xzf" firstAttribute="top" secondItem="sYm-um-Ih5" secondAttribute="top" id="ZN2-oR-9m1"/>
                                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="45" id="dr5-eM-cUJ"/>
+                                                                <constraint firstItem="j5T-A1-Xzf" firstAttribute="leading" secondItem="g6M-xY-41x" secondAttribute="trailing" id="zZR-yI-av4"/>
                                                             </constraints>
                                                         </view>
                                                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="AjK-Pt-Qtf">
@@ -4335,14 +4339,14 @@ Special thanks to the following people for making this app a reality:       
                                                             <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                                             <prototypes>
                                                                 <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="checkmark" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RegionCell" textLabel="pLs-75-mFz" style="IBUITableViewCellStyleDefault" id="ZjK-EK-BPJ">
-                                                                    <rect key="frame" x="0.0" y="55.5" width="375" height="46.5"/>
+                                                                    <rect key="frame" x="0.0" y="49.5" width="375" height="46.5"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZjK-EK-BPJ" id="dPN-IH-l2D">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="46.5"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="338.5" height="46.5"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pLs-75-mFz">
-                                                                                <rect key="frame" x="16" y="0.0" width="311" height="46.5"/>
+                                                                                <rect key="frame" x="16" y="0.0" width="314.5" height="46.5"/>
                                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                                 <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="17"/>
                                                                                 <nil key="textColor"/>
@@ -4586,21 +4590,21 @@ Special thanks to the following people for making this app a reality:       
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="FilterDistanceCell" id="eHV-N2-hyO" customClass="FilterDistanceCollectionViewCell" customModule="AW" customModuleProvider="target">
                                         <rect key="frame" x="750" y="0.0" width="375" height="574"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="mJ7-6L-elQ">
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="mJ7-6L-elQ">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0o4-Jp-iDP">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0o4-Jp-iDP">
                                                     <rect key="frame" x="0.0" y="0.0" width="375" height="80"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Filter by Distance:" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eRF-8X-sK0">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by Distance:" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eRF-8X-sK0">
                                                             <rect key="frame" x="15" y="0.0" width="288" height="80"/>
                                                             <color key="backgroundColor" name="white"/>
                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="23"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ojr-5H-RQy">
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ojr-5H-RQy">
                                                             <rect key="frame" x="311" y="24.5" width="51" height="31"/>
                                                             <color key="onTintColor" name="blue_oval"/>
                                                         </switch>
@@ -4616,15 +4620,15 @@ Special thanks to the following people for making this app a reality:       
                                                         <constraint firstAttribute="trailing" secondItem="ojr-5H-RQy" secondAttribute="trailing" constant="15" id="qad-LW-CQf"/>
                                                     </constraints>
                                                 </view>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XUC-FX-v6b">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XUC-FX-v6b">
                                                     <rect key="frame" x="0.0" y="95" width="375" height="128"/>
                                                     <subviews>
-                                                        <slider opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="250" continuous="NO" translatesAutoresizingMaskIntoConstraints="NO" id="339-LC-zX2">
+                                                        <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="250" continuous="NO" translatesAutoresizingMaskIntoConstraints="NO" id="339-LC-zX2">
                                                             <rect key="frame" x="28" y="62" width="319" height="34"/>
                                                             <color key="tintColor" name="font_clickable"/>
                                                             <color key="thumbTintColor" name="blue_oval"/>
                                                         </slider>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="How From From Your Current Location:" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FEz-SH-YES">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How From From Your Current Location:" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="FEz-SH-YES">
                                                             <rect key="frame" x="15" y="8" width="345" height="39"/>
                                                             <color key="backgroundColor" name="white"/>
                                                             <constraints>
@@ -4634,7 +4638,7 @@ Special thanks to the following people for making this app a reality:       
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Search Any Distance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PBV-J9-TB7">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search Any Distance" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PBV-J9-TB7">
                                                             <rect key="frame" x="30" y="103" width="315" height="17"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="17" id="t6c-Og-BhX"/>
@@ -4658,10 +4662,10 @@ Special thanks to the following people for making this app a reality:       
                                                         <constraint firstAttribute="height" constant="128" id="xv6-sp-EzN"/>
                                                     </constraints>
                                                 </view>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BNS-ZV-dAd">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BNS-ZV-dAd">
                                                     <rect key="frame" x="0.0" y="238" width="375" height="118"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Your Current Location:" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2LY-CD-cTO">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your Current Location:" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="2LY-CD-cTO">
                                                             <rect key="frame" x="15" y="15" width="345" height="28"/>
                                                             <color key="backgroundColor" name="white"/>
                                                             <constraints>
@@ -4678,19 +4682,19 @@ Special thanks to the following people for making this app a reality:       
                                                                 <constraint firstAttribute="width" constant="19" id="mPl-OH-pk1"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Location Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qo8-5B-MEM">
-                                                            <rect key="frame" x="42" y="45" width="318" height="19"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qo8-5B-MEM">
+                                                            <rect key="frame" x="42" y="45" width="318" height="22"/>
                                                             <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="16"/>
                                                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Address or Geopoints" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i4E-S9-oP1">
-                                                            <rect key="frame" x="42" y="62" width="318" height="15.5"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Address or Geopoints" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i4E-S9-oP1">
+                                                            <rect key="frame" x="42" y="65" width="318" height="18"/>
                                                             <fontDescription key="fontDescription" name="OpenSans-Regular" family="Open Sans" pointSize="13"/>
                                                             <color key="textColor" name="font_grey"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" hidesWhenStopped="YES" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="ccW-5C-G4h">
+                                                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="ccW-5C-G4h">
                                                             <rect key="frame" x="169" y="40.5" width="37" height="37"/>
                                                             <color key="color" name="blue_oval"/>
                                                         </activityIndicatorView>
@@ -4713,7 +4717,7 @@ Special thanks to the following people for making this app a reality:       
                                                         <constraint firstAttribute="trailing" secondItem="Qo8-5B-MEM" secondAttribute="trailing" constant="15" id="ykt-Bg-2tm"/>
                                                     </constraints>
                                                 </view>
-                                                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J6o-b6-X3J">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J6o-b6-X3J">
                                                     <rect key="frame" x="15" y="371" width="345" height="45"/>
                                                     <color key="backgroundColor" name="primary"/>
                                                     <constraints>
@@ -4979,10 +4983,10 @@ Don't worry, you'll be checking levels in no time!</string>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="accidentCell" rowHeight="106" id="d4P-pw-tCg" customClass="AccidentTableViewCell" customModule="AW" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="106"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="106"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="d4P-pw-tCg" id="YxV-dT-DQ2">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="106"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="106"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="057-m8-ghS">
@@ -4995,7 +4999,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Eo3-Cg-MvM">
-                                                    <rect key="frame" x="20" y="28" width="320" height="70"/>
+                                                    <rect key="frame" x="20" y="28" width="322" height="70"/>
                                                     <attributedString key="attributedText">
                                                         <fragment content="Label">
                                                             <attributes>
@@ -5022,7 +5026,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="noAccidentCell" rowHeight="70" id="K3k-wg-DwN">
-                                        <rect key="frame" x="0.0" y="156" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="150.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="K3k-wg-DwN" id="tLY-bK-CGB">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -5237,7 +5241,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Stats" id="cSo-Xd-4qn">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="statsCell" rowHeight="67" id="Eb3-wj-pd7">
-                                        <rect key="frame" x="0.0" y="203" width="375" height="67"/>
+                                        <rect key="frame" x="0.0" y="197" width="375" height="67"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Eb3-wj-pd7" id="jr5-tY-Qsk">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="67"/>
@@ -5325,7 +5329,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Factors" id="mEE-sW-bJA">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="factorCell" rowHeight="45" id="wk2-ku-R8V">
-                                        <rect key="frame" x="0.0" y="326" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="314" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wk2-ku-R8V" id="fCk-tZ-hmr">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5351,7 +5355,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Injuries" id="KwJ-15-fER">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="injuryCell" rowHeight="45" id="l8a-5B-9mT">
-                                        <rect key="frame" x="0.0" y="427" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="409" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="l8a-5B-9mT" id="Xau-22-LIc">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5377,7 +5381,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="causes" id="zJv-vm-EZf">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="causeCell" rowHeight="45" id="foV-Cm-DfP">
-                                        <rect key="frame" x="0.0" y="528" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="504" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="foV-Cm-DfP" id="Utq-Ae-4Vh">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5403,7 +5407,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="Description" id="Rkx-Ib-rli">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="descriptionCell" rowHeight="45" id="WZV-gh-fPn">
-                                        <rect key="frame" x="0.0" y="629" width="375" height="45"/>
+                                        <rect key="frame" x="0.0" y="599" width="375" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WZV-gh-fPn" id="Kxt-m8-thR">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
@@ -5469,7 +5473,7 @@ Don't worry, you'll be checking levels in no time!</string>
                         <color key="separatorColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="xcv-oT-ggc">
-                            <rect key="frame" x="0.0" y="720" width="375" height="65"/>
+                            <rect key="frame" x="0.0" y="698.00000152587893" width="375" height="65"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bJ-07-V3N">
@@ -5496,7 +5500,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection footerTitle="" id="S9w-MJ-218">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="74" id="Wdx-fC-yLU">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="74"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="375" height="74"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Wdx-fC-yLU" id="l3f-Hk-OlX">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="74"/>
@@ -5538,7 +5542,7 @@ Don't worry, you'll be checking levels in no time!</string>
                             <tableViewSection headerTitle="" id="mcT-Tv-JzW">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="270" id="0wG-vb-4Ac">
-                                        <rect key="frame" x="0.0" y="202" width="375" height="270"/>
+                                        <rect key="frame" x="0.0" y="185.50000076293946" width="375" height="270"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0wG-vb-4Ac" id="Op9-0h-sVV">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="270"/>
@@ -5608,7 +5612,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="55" id="uDV-aj-Yty">
-                                        <rect key="frame" x="0.0" y="472" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="455.50000076293946" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uDV-aj-Yty" id="qxR-4L-1Nk">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
@@ -5630,7 +5634,7 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="55" id="B3v-d1-DYe">
-                                        <rect key="frame" x="0.0" y="527" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="510.50000076293941" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="B3v-d1-DYe" id="R0x-ET-Dpa">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
@@ -5707,14 +5711,14 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="55" id="AM8-Ou-TQJ">
-                                        <rect key="frame" x="0.0" y="582" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="565.50000076293941" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AM8-Ou-TQJ" id="4Dy-uI-ARq">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="55"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="55"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Runnable" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rwI-X6-5Ub">
-                                                    <rect key="frame" x="151" y="0.0" width="189" height="55"/>
+                                                    <rect key="frame" x="151" y="0.0" width="191" height="55"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                     <color key="textColor" name="primary"/>
                                                     <nil key="highlightedColor"/>
@@ -5741,10 +5745,10 @@ Don't worry, you'll be checking levels in no time!</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="55" id="mO8-WE-2J1">
-                                        <rect key="frame" x="0.0" y="637" width="375" height="55"/>
+                                        <rect key="frame" x="0.0" y="620.50000076293941" width="375" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mO8-WE-2J1" id="5V2-Fr-fn5">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="55"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="358" height="55"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="July 1, 2020 4:33pm" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QFQ-Nm-LfI">
@@ -5846,6 +5850,7 @@ Don't worry, you'll be checking levels in no time!</string>
         <image name="runnablePin" width="19" height="28"/>
         <image name="share" width="19" height="20"/>
         <image name="tmpImageGray" width="171" height="171"/>
+        <image name="xmark.circle" catalog="system" width="128" height="121"/>
         <namedColor name="accent">
             <color red="0.95294117647058818" green="0.36078431372549019" blue="0.28627450980392155" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/American Whitewater/Helpers/DefaultsManager.swift
+++ b/American Whitewater/Helpers/DefaultsManager.swift
@@ -77,6 +77,28 @@ class DefaultsManager {
     // MARK: - Filters
     //
     
+    public var filters: Filters {
+        get {
+            .init(
+                showDistanceFilter: showDistanceFilter,
+                showRegionFilter: showRegionFilter,
+                regionsFilter: regionsFilter,
+                distanceFilter: distanceFilter,
+                classFilter: classFilter,
+                runnableFilter: runnableFilter
+            )
+        }
+        
+        set {
+            showDistanceFilter = newValue.showDistanceFilter
+            showRegionFilter = newValue.showRegionFilter
+            regionsFilter = newValue.regionsFilter
+            distanceFilter = newValue.distanceFilter
+            classFilter = newValue.classFilter
+            runnableFilter = newValue.runnableFilter
+        }
+    }
+    
     var showDistanceFilter: Bool {
         get { defaults.bool(forKey: Keys.showDistanceFilter) }
         set { defaults.set(newValue, forKey: Keys.showDistanceFilter) }
@@ -148,11 +170,6 @@ class DefaultsManager {
     var signedInAuth: String? {
         get { defaults.string(forKey: Keys.signedInAuth) }
         set { defaults.set(newValue, forKey: Keys.signedInAuth) }
-    }
-    
-    var signInAlertCount: Int {
-        get { defaults.integer(forKey: Keys.signInAlertCount) }
-        set { defaults.set(newValue, forKey: Keys.signInAlertCount) }
     }
     
     var signInLastShown: Date? {

--- a/American Whitewater/Helpers/DefaultsManager.swift
+++ b/American Whitewater/Helpers/DefaultsManager.swift
@@ -3,6 +3,10 @@ import SwiftyJSON
 import KeychainSwift
 import CoreLocation
 
+extension Notification.Name {
+    static let filtersDidChange = Notification.Name("filtersDidChange")
+}
+
 class DefaultsManager {
     public static let shared = DefaultsManager()
     
@@ -90,12 +94,22 @@ class DefaultsManager {
         }
         
         set {
+            // Don't set/notify on duplicates:
+            guard newValue != filters else {
+                return
+            }
+            
             showDistanceFilter = newValue.showDistanceFilter
             showRegionFilter = newValue.showRegionFilter
             regionsFilter = newValue.regionsFilter
             distanceFilter = newValue.distanceFilter
             classFilter = newValue.classFilter
             runnableFilter = newValue.runnableFilter
+            
+            // Post a notification to make it easier to respond to a change in filters
+            // This could be also be done with combine (filters could be @Published)
+            // but this is a smaller change to the app:
+            NotificationCenter.default.post(name: .filtersDidChange, object: newValue)
         }
     }
     

--- a/American Whitewater/Helpers/DefaultsManager.swift
+++ b/American Whitewater/Helpers/DefaultsManager.swift
@@ -99,17 +99,17 @@ class DefaultsManager {
         }
     }
     
-    var showDistanceFilter: Bool {
+    private var showDistanceFilter: Bool {
         get { defaults.bool(forKey: Keys.showDistanceFilter) }
         set { defaults.set(newValue, forKey: Keys.showDistanceFilter) }
     }
 
-    var showRegionFilter: Bool {
+    private var showRegionFilter: Bool {
         get { defaults.bool(forKey: Keys.showRegionFilter) }
         set { defaults.set(newValue, forKey: Keys.showRegionFilter) }
     }
     
-    var regionsFilter: [String] {
+    private var regionsFilter: [String] {
         get {
             (defaults.array(forKey: Keys.regionsFilter) as? [String]) ??
             []
@@ -117,7 +117,7 @@ class DefaultsManager {
         set { defaults.set(newValue, forKey: Keys.regionsFilter) }
     }
 
-    var distanceFilter: Double {
+    private var distanceFilter: Double {
         get {
             (defaults.object(forKey: Keys.distanceFilter) as? Double) ??
             100
@@ -127,7 +127,7 @@ class DefaultsManager {
         }
     }
     
-    var classFilter: [Int] {
+    private var classFilter: [Int] {
         get {
             (defaults.array(forKey: Keys.classFilter) as? [Int]) ??
             []
@@ -135,7 +135,7 @@ class DefaultsManager {
         set { defaults.set(newValue, forKey: Keys.classFilter) }
     }
     
-    var runnableFilter: Bool {
+    private var runnableFilter: Bool {
         get { defaults.bool(forKey: Keys.runnableFilter) }
         set { defaults.set(newValue, forKey: Keys.runnableFilter) }
     }

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -9,10 +9,109 @@
 import Foundation
 
 struct Filters {
+    // FIXME: currently it appears that the app tries to treat these as a toggle, i.e. if showDistanceFilter = true, showRegionFilter must be false and vice versa. So why have both? Or should it be an enum?
+    // (See below, the predicates mostly
     var showDistanceFilter: Bool
     var showRegionFilter: Bool
+    
     var regionsFilter: [String]
     var distanceFilter: Double
     var classFilter: [Int]
     var runnableFilter: Bool
+}
+
+//
+// MARK: - Predicates
+//
+
+extension Filters {
+    private var runnablePredicate: NSPredicate? {
+        guard runnableFilter else {
+            return nil
+        }
+        
+        return NSPredicate(format: "condition == %@ || condition == %@", "med", "high")
+    }
+    
+    private var difficultiesPredicate: NSCompoundPredicate? {
+        guard !classFilter.isEmpty else {
+            return nil
+        }
+        
+        let classPredicates = classFilter.map {
+            NSPredicate(format: "difficulty\($0) == TRUE")
+        }
+
+        return NSCompoundPredicate(orPredicateWithSubpredicates: classPredicates)
+    }
+    
+    private var regionsPredicate: NSPredicate? {
+        // if we are filtering by distance then ignore regions
+        // FIXME: surely this should be changed to `guard showRegionFilter else { return nil }`? (but see fixme above about these props)
+        if showDistanceFilter {
+            return nil
+        }
+        
+        let states = regionsFilter.compactMap {
+            Region.regionByCode(code: $0)?.apiResponse
+        }
+        
+        guard !states.isEmpty else {
+            return nil
+        }
+        
+        return NSPredicate(format: "state IN[cd] %@", states)
+    }
+
+    private var distancePredicate: NSPredicate? {
+        guard
+            showDistanceFilter,
+            distanceFilter > 0
+        else {
+            return nil
+        }
+        
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "distance <= %lf", distanceFilter),
+            NSPredicate(format: "distance != 0") // hide invalid distances
+        ])
+    }
+    
+    // based on our filtering settings (distance, region, or class) we request Reaches that
+    // match these settings
+    public func combinedPredicate() -> NSPredicate {
+        let subPredicates = [
+            difficultiesPredicate,
+            runnablePredicate,
+            distancePredicate,
+            regionsPredicate
+        ]
+            .compactMap { $0 }
+        
+        return NSCompoundPredicate(andPredicateWithSubpredicates: subPredicates)
+    }
+}
+
+//
+// MARK: - Sort descriptors
+//
+    
+extension Filters {
+    public static let sortByDistanceAndName = [
+        NSSortDescriptor(key: "distance", ascending: true),
+        NSSortDescriptor(key: "name", ascending: true)
+    ]
+    
+    public static let sortByName = [
+        NSSortDescriptor(key: "name", ascending: true),
+        NSSortDescriptor(key: "sortName", ascending: true)
+    ]
+    
+    public var sortDescriptors: [NSSortDescriptor] {
+        if showDistanceFilter, distanceFilter > 0 {
+            return Self.sortByDistanceAndName
+        } else {
+            return Self.sortByName
+        }
+    }
 }

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -31,6 +31,15 @@ struct Filters {
         classFilter: [1,2,3,4,5],
         runnableFilter: false
     )
+    
+    static let defaultByDistanceFilters = Filters(
+        showDistanceFilter: true,
+        showRegionFilter: false,
+        regionsFilter: [],
+        distanceFilter: 100,
+        classFilter: [1,2,3,4,5],
+        runnableFilter: false
+    )
 }
 
 //

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -32,13 +32,11 @@ struct Filters: Equatable {
         classFilter: [1,2,3,4,5],
         runnableFilter: false
     )
-}
-
-//
-// MARK: - Predicates
-//
-
-extension Filters {
+    
+    //
+    // MARK: - Predicates
+    //
+    
     private var runnablePredicate: NSPredicate? {
         guard runnableFilter else {
             return nil
@@ -55,7 +53,7 @@ extension Filters {
         let classPredicates = classFilter.map {
             NSPredicate(format: "difficulty\($0) == TRUE")
         }
-
+        
         return NSCompoundPredicate(orPredicateWithSubpredicates: classPredicates)
     }
     
@@ -76,7 +74,7 @@ extension Filters {
         
         return NSPredicate(format: "state IN[cd] %@", states)
     }
-
+    
     private var distancePredicate: NSPredicate? {
         guard
             showDistanceFilter,
@@ -104,13 +102,11 @@ extension Filters {
         
         return NSCompoundPredicate(andPredicateWithSubpredicates: subPredicates)
     }
-}
-
-//
-// MARK: - Sort descriptors
-//
     
-extension Filters {
+    //
+    // MARK: - Sort descriptors
+    //
+    
     public static let sortByDistanceAndName = [
         NSSortDescriptor(key: "distance", ascending: true),
         NSSortDescriptor(key: "name", ascending: true)

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -18,6 +18,19 @@ struct Filters {
     var distanceFilter: Double
     var classFilter: [Int]
     var runnableFilter: Bool
+    
+    //
+    // MARK: - Some defaults for first run or resetting
+    //
+    
+    static let defaultByRegionFilters = Filters(        
+        showDistanceFilter: false,
+        showRegionFilter: true,
+        regionsFilter: [], // FIXME?
+        distanceFilter: 100,
+        classFilter: [1,2,3,4,5],
+        runnableFilter: false
+    )
 }
 
 //

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -1,0 +1,18 @@
+//
+//  Filters.swift
+//  Filters
+//
+//  Created by Phillip Kast on 7/28/21.
+//  Copyright © 2021 American Whitewater. All rights reserved.
+//
+
+import Foundation
+
+struct Filters {
+    var showDistanceFilter: Bool
+    var showRegionFilter: Bool
+    var regionsFilter: [String]
+    var distanceFilter: Double
+    var classFilter: [Int]
+    var runnableFilter: Bool
+}

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -1,11 +1,3 @@
-//
-//  Filters.swift
-//  Filters
-//
-//  Created by Phillip Kast on 7/28/21.
-//  Copyright © 2021 American Whitewater. All rights reserved.
-//
-
 import Foundation
 
 struct Filters: Equatable {

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Filters {
+struct Filters: Equatable {
     // FIXME: currently it appears that the app tries to treat these as a toggle, i.e. if showDistanceFilter = true, showRegionFilter must be false and vice versa. So why have both? Or should it be an enum?
     // (See below, the predicates mostly
     var showDistanceFilter: Bool

--- a/American Whitewater/Helpers/Regions.swift
+++ b/American Whitewater/Helpers/Regions.swift
@@ -6,6 +6,10 @@ struct Region {
     let country: String
     let apiResponse: String
     
+    var abbreviation: Substring {
+        code.suffix(2)
+    }
+    
     static let all: [Region] = [
         Region(code: "stAL", title: "Alabama", country: "US", apiResponse: "USA-ALB"),
         Region(code: "stAK", title: "Alaska", country: "US", apiResponse: "USA-ALK"),

--- a/American Whitewater/ViewControllers/Filtering/FilterViewController.swift
+++ b/American Whitewater/ViewControllers/Filtering/FilterViewController.swift
@@ -150,7 +150,6 @@ class FilterViewController: UIViewController {
     @objc func distanceSliderChanged(distanceSlider: UISlider) {
         filters.distanceFilter = Double(distanceSlider.value)
         distanceFilterLabel?.text = distanceFilterDescription
-        contentCollectionView.reloadData()
     }
     
     //


### PR DESCRIPTION
- Add a Filters struct with same properties as the filtering bits of DefaultsManager
- Extract predicate generation from RunsListViewController to Filters
- Remove predicate stuff from MapViewController, use Filters instead
- Make a static default filter to set on first run
- Use DefaultsManager.shared.filters to manipulate filters in OnboardLocationViewController
- Maintain FilterViewController state while editing in a Filters var, and save it on dismiss
- Mark backing store of filter properties in DefaultsManager private
- More refactor of FilterViewController
- Reorganize FilterViewController file
- Use xmark.circle (SF Symbol) for clear region filters button in FilterViewController
- Not necessary to reload the filter controller's collection view every time the distance slider changes
- Post a notification when DefaultsManager.filters change
- Change map view fetched results controller lifecycle:
- Another try: show loading cell or 'no rivers available' cell as appropriate
