### PR TITLE
Use enum for FilterType and fix Reach Section

### DIFF
--- a/American Whitewater/AppDelegate.swift
+++ b/American Whitewater/AppDelegate.swift
@@ -51,11 +51,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // This nice library moves text fields out of the way of the keyboard automagically
         IQKeyboardManager.shared.enable = true
         
-        // setting first values for first run
-        if !DefaultsManager.shared.completedFirstRun {
-            DefaultsManager.shared.filters = Filters.defaultByRegionFilters
-        }
-        
         // This sets preferred status bar style to .lightContent within our nav controllers
         UINavigationBar.appearance().barStyle = .black
         

--- a/American Whitewater/Helpers/AWApiReachHelper.swift
+++ b/American Whitewater/Helpers/AWApiReachHelper.swift
@@ -217,11 +217,8 @@ class AWApiReachHelper {
             reach.gageMin = newReach.gauge_min
             reach.state = newReach.state
             
-            if let altName = newReach.altname, !altName.isEmpty {
-                reach.section = altName
-            } else {
-               reach.section = newReach.section
-            }
+            reach.altname = newReach.altname
+            reach.section = newReach.section
 
             // API returns the total seconds before the present time as a string
             // converting this to a Date

--- a/American Whitewater/Helpers/DefaultsManager.swift
+++ b/American Whitewater/Helpers/DefaultsManager.swift
@@ -79,8 +79,7 @@ class DefaultsManager {
     public var filters: Filters {
         get {
             .init(
-                showDistanceFilter: showDistanceFilter,
-                showRegionFilter: showRegionFilter,
+                filterType: filterType,
                 regionsFilter: regionsFilter,
                 distanceFilter: distanceFilter,
                 classFilter: classFilter,
@@ -94,8 +93,7 @@ class DefaultsManager {
                 return
             }
             
-            showDistanceFilter = newValue.showDistanceFilter
-            showRegionFilter = newValue.showRegionFilter
+            filterType = newValue.filterType
             regionsFilter = newValue.regionsFilter
             distanceFilter = newValue.distanceFilter
             classFilter = newValue.classFilter
@@ -108,14 +106,15 @@ class DefaultsManager {
         }
     }
     
-    private var showDistanceFilter: Bool {
-        get { defaults.bool(forKey: Keys.showDistanceFilter) }
-        set { defaults.set(newValue, forKey: Keys.showDistanceFilter) }
-    }
-
-    private var showRegionFilter: Bool {
-        get { defaults.bool(forKey: Keys.showRegionFilter) }
-        set { defaults.set(newValue, forKey: Keys.showRegionFilter) }
+    private var filterType: FilterType {
+        get {
+            let raw = defaults.string(forKey: Keys.filterType) ?? FilterType.Region.rawValue
+            return FilterType(rawValue: raw)!
+        }
+        set(newFilterType) {
+            let raw = newFilterType.rawValue
+            defaults.set(raw, forKey: Keys.filterType)
+        }
     }
     
     private var regionsFilter: [String] {
@@ -139,7 +138,7 @@ class DefaultsManager {
     private var classFilter: [Int] {
         get {
             (defaults.array(forKey: Keys.classFilter) as? [Int]) ??
-            []
+                [1,2,3,4,5]
         }
         set { defaults.set(newValue, forKey: Keys.classFilter) }
     }
@@ -239,8 +238,7 @@ class DefaultsManager {
         static let onboardingCompleted = "onboardingCompletedKey"
         static let regionsFilter = "regionsFilterKey"
         static let distanceFilter = "distanceFilterKey"
-        static let showDistanceFilter = "showDistanceFilterKey"
-        static let showRegionFilter = "showRegionFilterKey"
+        static let filterType = "filterType"
         static let latitude = "latitudeKey"
         static let longitude = "longitudeKey"
         static let classFilter = "classFilterKey"

--- a/American Whitewater/Helpers/DefaultsManager.swift
+++ b/American Whitewater/Helpers/DefaultsManager.swift
@@ -108,7 +108,7 @@ class DefaultsManager {
     
     private var filterType: FilterType {
         get {
-            let raw = defaults.string(forKey: Keys.filterType) ?? FilterType.Region.rawValue
+            let raw = defaults.string(forKey: Keys.filterType) ?? FilterType.region.rawValue
             return FilterType(rawValue: raw)!
         }
         set(newFilterType) {

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 enum FilterType: String {
-    case Region = "region"
-    case Distance = "distance"
+    case region
+    case distance
 }
 
 struct Filters: Equatable {
@@ -18,7 +18,7 @@ struct Filters: Equatable {
     //
     
     static let defaultByRegionFilters = Filters(
-        filterType: FilterType.Region,
+        filterType: .region,
         regionsFilter: [], // FIXME?
         distanceFilter: 100,
         classFilter: [1,2,3,4,5],
@@ -26,18 +26,18 @@ struct Filters: Equatable {
     )
     
     static let defaultByDistanceFilters = Filters(
-        filterType: FilterType.Distance,
+        filterType: .distance,
         regionsFilter: [],
         distanceFilter: 100,
         classFilter: [1,2,3,4,5],
         runnableFilter: false
     )
     public var isRegion: Bool {
-        return filterType == FilterType.Region
+        return filterType == .region
     }
     
     public var isDistance: Bool {
-        return filterType == FilterType.Distance
+        return filterType == .distance
     }
     
     //

--- a/American Whitewater/Helpers/Filters.swift
+++ b/American Whitewater/Helpers/Filters.swift
@@ -1,10 +1,12 @@
 import Foundation
 
+enum FilterType: String {
+    case Region = "region"
+    case Distance = "distance"
+}
+
 struct Filters: Equatable {
-    // FIXME: currently it appears that the app tries to treat these as a toggle, i.e. if showDistanceFilter = true, showRegionFilter must be false and vice versa. So why have both? Or should it be an enum?
-    // (See below, the predicates mostly
-    var showDistanceFilter: Bool
-    var showRegionFilter: Bool
+    var filterType: FilterType
     
     var regionsFilter: [String]
     var distanceFilter: Double
@@ -15,9 +17,8 @@ struct Filters: Equatable {
     // MARK: - Some defaults for first run or resetting
     //
     
-    static let defaultByRegionFilters = Filters(        
-        showDistanceFilter: false,
-        showRegionFilter: true,
+    static let defaultByRegionFilters = Filters(
+        filterType: FilterType.Region,
         regionsFilter: [], // FIXME?
         distanceFilter: 100,
         classFilter: [1,2,3,4,5],
@@ -25,13 +26,19 @@ struct Filters: Equatable {
     )
     
     static let defaultByDistanceFilters = Filters(
-        showDistanceFilter: true,
-        showRegionFilter: false,
+        filterType: FilterType.Distance,
         regionsFilter: [],
         distanceFilter: 100,
         classFilter: [1,2,3,4,5],
         runnableFilter: false
     )
+    public var isRegion: Bool {
+        return filterType == FilterType.Region
+    }
+    
+    public var isDistance: Bool {
+        return filterType == FilterType.Distance
+    }
     
     //
     // MARK: - Predicates
@@ -58,9 +65,7 @@ struct Filters: Equatable {
     }
     
     private var regionsPredicate: NSPredicate? {
-        // if we are filtering by distance then ignore regions
-        // FIXME: surely this should be changed to `guard showRegionFilter else { return nil }`? (but see fixme above about these props)
-        if showDistanceFilter {
+        if !isRegion {
             return nil
         }
         
@@ -77,7 +82,7 @@ struct Filters: Equatable {
     
     private var distancePredicate: NSPredicate? {
         guard
-            showDistanceFilter,
+            isDistance,
             distanceFilter > 0
         else {
             return nil
@@ -118,7 +123,7 @@ struct Filters: Equatable {
     ]
     
     public var sortDescriptors: [NSSortDescriptor] {
-        if showDistanceFilter, distanceFilter > 0 {
+        if isDistance, distanceFilter > 0 {
             return Self.sortByDistanceAndName
         } else {
             return Self.sortByName

--- a/American Whitewater/ViewControllers/Filtering/FilterViewController.swift
+++ b/American Whitewater/ViewControllers/Filtering/FilterViewController.swift
@@ -127,7 +127,7 @@ class FilterViewController: UIViewController {
     }
     
     func updateFilterBy(shouldFilterByRegion: Bool) {
-        filters.filterType = shouldFilterByRegion ? FilterType.Region : FilterType.Distance
+        filters.filterType = shouldFilterByRegion ? FilterType.region : FilterType.distance
         
         contentCollectionView.reloadData()
     }

--- a/American Whitewater/ViewControllers/Filtering/FilterViewController.swift
+++ b/American Whitewater/ViewControllers/Filtering/FilterViewController.swift
@@ -127,13 +127,7 @@ class FilterViewController: UIViewController {
     }
     
     func updateFilterBy(shouldFilterByRegion: Bool) {
-        if shouldFilterByRegion {
-            filters.showRegionFilter = true
-            filters.showDistanceFilter = false
-        } else {
-            filters.showRegionFilter = false
-            filters.showDistanceFilter = true
-        }
+        filters.filterType = shouldFilterByRegion ? FilterType.Region : FilterType.Distance
         
         contentCollectionView.reloadData()
     }
@@ -156,8 +150,8 @@ class FilterViewController: UIViewController {
     //
     
     @IBAction func doneButtonPressed(_ sender: Any) {
-        // FIXME: why isn't this OK for the user to do?
-        if filters.showRegionFilter, filters.regionsFilter.isEmpty {
+        // We want to encourage people to choose a region, and not accidentally get data for the whole country, which is slow
+        if filters.isRegion, filters.regionsFilter.isEmpty {
             DuffekDialog.shared.showOkDialog(title: "Region Required", message: "Please select a region or choose to filter by Distance before continuing")
             
             return
@@ -197,8 +191,8 @@ extension FilterViewController: UICollectionViewDelegate, UICollectionViewDataSo
             cell.regionTableView.reloadData()
             
             // only show region info if we are using region filters
-            cell.regionContainerView.isHidden = !filters.showRegionFilter
-            cell.showRegionsViewSwitch.isOn = filters.showRegionFilter
+            cell.regionContainerView.isHidden = !filters.isRegion
+            cell.showRegionsViewSwitch.isOn = filters.isRegion
             cell.showRegionsViewSwitch.addTarget(self, action: #selector(filterByRegionSwitchChanged(_:)), for: .valueChanged)
             
             return cell
@@ -237,7 +231,7 @@ extension FilterViewController: UICollectionViewDelegate, UICollectionViewDataSo
             cell.currentLocationAddressLabel.text = ""
             
             // setup filter switch and visibility as needed
-            if !filters.showDistanceFilter {
+            if !filters.isDistance {
                 cell.filterByDistanceSwitch.isOn = false
                 cell.currentLocationViewContainer.isHidden = true
                 cell.filterDistanceSliderViewContainer.isHidden = true

--- a/American Whitewater/ViewControllers/Map/MapViewController.swift
+++ b/American Whitewater/ViewControllers/Map/MapViewController.swift
@@ -94,8 +94,8 @@ class MapViewController: UIViewController, MKMapViewDelegate, CLLocationManagerD
     
     func updateFilterButton() {
         navigationItem.rightBarButtonItem?.title = ""
-        
-        let imageName = (filters.classFilter.count < 5 || filters.showDistanceFilter) ? "filterOn" : "filterOff"
+
+        let imageName = (filters.classFilter.count < 5 || filters.isDistance) ? "filterOn" : "filterOff"
         navigationItem.rightBarButtonItem?.setBackgroundImage(UIImage(named: imageName), for: .normal, barMetrics: .default)
     }
     

--- a/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
@@ -135,7 +135,7 @@ class RunsListViewController: UIViewController {
                 self.showToast(message: "Error fetching data: " + error.localizedDescription)
             }
             
-            if filters.showRegionFilter {
+            if filters.isRegion {
                 if filters.regionsFilter.isEmpty {
                     DuffekDialog.shared.showStandardDialog(title: "Pull All Data?", message: "You didn't select a region or distance to pull data from. This will download all river data for the USA.\n\nOn a slower connection this can take a few minutes.\n\nYou can set filters to speed this up.", buttonTitle: "Continue", buttonFunction: {
                         self.refreshByRegion(success: onUpdateSuccessful, failure: onUpdateFailed)


### PR DESCRIPTION
Fixes #245, #244, #196.

Fixes section name:
- App was using the `altname` if present, but should be using section name throughout. This behavior was used because often the altnames are the more colloquially used names. However, we want to match the website behavior.

Use enum for FilterType:
- I also added `isRegion` and `isDistance` to the filters class for convenience. Essentially, the interface is the same, but the handling in defaults isn't repetitive. 

Set default filter in DefaultsManager
- I added the default values to DefaultsManager
- However, I ended up keeping the ability to set filters back to defaults, because it's more explicit than depending on the state of the defaults manager. 