### PR TITLE
Calculate reach distances when user location is updated.

### DIFF
--- a/American Whitewater/ViewControllers/Map/MapViewController.swift
+++ b/American Whitewater/ViewControllers/Map/MapViewController.swift
@@ -75,13 +75,6 @@ class MapViewController: UIViewController, MKMapViewDelegate {
             return
         }
         
-        // Do nothing if new location is close to old location
-        let MIN_DISTANCE_m = 100.0
-        if let lastLocation = lastLocation, lastLocation.distance(from: newLocation) < MIN_DISTANCE_m {
-            print("Last Location Distance to new location: \(lastLocation.distance(from: newLocation))")
-            return
-        }
-        
         DefaultsManager.shared.coordinate = newLocation.coordinate
         self.lastLocation = newLocation
     }

--- a/American Whitewater/ViewControllers/Map/MapViewController.swift
+++ b/American Whitewater/ViewControllers/Map/MapViewController.swift
@@ -76,18 +76,10 @@ class MapViewController: UIViewController, MKMapViewDelegate {
         }
         
         // Do nothing if new location is close to old location
-        if let lastLocation = lastLocation, lastLocation.distance(from: newLocation) < 100 {
+        let MIN_DISTANCE_m = 100.0
+        if let lastLocation = lastLocation, lastLocation.distance(from: newLocation) < MIN_DISTANCE_m {
             print("Last Location Distance to new location: \(lastLocation.distance(from: newLocation))")
             return
-        }
-        
-        // check if we need to update distances
-        if newLocation.coordinate.hasChanged(from: DefaultsManager.shared.coordinate, byMoreThan: 0.01) {
-            print("Updating distances of reaches")
-            
-            reachUpdater.updateAllReachDistances {
-                self.fetchReachesFromCoreData()
-            }
         }
         
         DefaultsManager.shared.coordinate = newLocation.coordinate


### PR DESCRIPTION
This PR calculates the user's distance to the reaches when their location is updated. Formerly, this update was only happening if the user's location got updated on the map view. 

The code is a bit hacky. The constraints are:
1. lat/lng are stored as Strings instead of numbers, which makes comparison and calculations costly.
2. the distances are updated to core data. 

Both of these constraints make it difficult to do this calculation quickly. Ideally, we would perform this calculation at the time it's needed (on the run list or map view controller). If we end up ripping out core data, we can change the data types, and clean everything up. 

Hopefully this fixes https://github.com/AmericanWhitewater/aw-ios/issues/239, 