### PR TITLE
Set Reach.detailUpdated when details are updated. Use it for the date shown in detail controller, if available

### DIFF
--- a/American Whitewater/API/ReachUpdater.swift
+++ b/American Whitewater/API/ReachUpdater.swift
@@ -283,6 +283,7 @@ class ReachUpdater {
         reach.longDescription = details.detailDescription
         reach.shuttleDetails = details.detailShuttleDescription
         reach.gageName = details.detailGageName
+        reach.detailUpdated = Date()
         
         if let rapidsList = details.detailRapids {
             for rapid in rapidsList {

--- a/American Whitewater/ViewControllers/Reaches/RunDetailTableViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunDetailTableViewController.swift
@@ -204,9 +204,11 @@ class RunDetailTableViewController: UITableViewController {
         runNameLabel.text = reach.name ?? "Unknown"
         runSectionLabel.text = reach.section ?? ""
         
-        // FIXME: Date() is not the right date to use
-        // Reach.detailUpdated is a property in the CD model, but it is never set
-        lastUpdateLabel.text = dateFormatter.string(from: Date())
+        if let d = reach.detailUpdated {
+            lastUpdateLabel.text = dateFormatter.string(from: d)
+        } else {
+            lastUpdateLabel.text = nil
+        }
         
         runUnitsLabel.text = selectedRun?.unit ?? ""
         runGaugeDeltaLabel.text = selectedRun?.delta ?? ""


### PR DESCRIPTION
And, if not available, don't show a date on the detail screen. Previously, it always showed the current date -- not correct if offline.

Fixes #255 