### PR TITLE
Fix run list crash

### DIFF
--- a/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
@@ -415,6 +415,13 @@ extension RunsListViewController: UITableViewDelegate, UITableViewDataSource {
         }
     }
     
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        if indexPath.section == 1 {
+            return nil
+        }
+        return indexPath
+    }
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let selectedRun = fetchedResultsController?.object(at: indexPath) else {
             return


### PR DESCRIPTION
Fix the [crash](https://console.firebase.google.com/project/american-whitewater-1234/crashlytics/app/ios:org.americanwhitewater.aw/issues/f689ac903c2b29a91ed475fa00fcb8e0?time=last-thirty-days&sessionEventKey=52b21a32dd2841029fbe7198952b65dd_1597012327096437796) in the run list view controller. 

Selecting the cell for the "no results" state was causing the crash.
