### PR TITLE
change detail timestamp to reflect gauge updates and allow refresh fr…

### DIFF
--- a/American Whitewater/API/ReachUpdater.swift
+++ b/American Whitewater/API/ReachUpdater.swift
@@ -50,7 +50,6 @@ class ReachUpdater {
                     
                     self.mergeMainContext(
                         completion: {
-                            DefaultsManager.shared.lastUpdated = Date()
                             completion(nil)
                         },
                         errorCallback: completion
@@ -82,8 +81,6 @@ class ReachUpdater {
                     
                     self.mergeMainContext(
                         completion: {
-                            DefaultsManager.shared.lastUpdated = Date()
-                            
                             // FIXME: This call is used for things other than favorites. This needs to be set elsewhere
                             DefaultsManager.shared.favoritesLastUpdated = Date()
 

--- a/American Whitewater/API/Reaches (non-gql)/AWApiReachHelper.swift
+++ b/American Whitewater/API/Reaches (non-gql)/AWApiReachHelper.swift
@@ -96,7 +96,7 @@ class AWApiReachHelper {
                         }
                     }
                 
-                    print("Processed \(riversList.count) favorite rivers.")
+                    print("Processed \(riversList.count) rivers.")
                 
                     callback(riversList)
 

--- a/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
+++ b/American Whitewater/ViewControllers/Reaches/RunsListViewController.swift
@@ -56,6 +56,7 @@ class RunsListViewController: UIViewController {
                     }
                     
                     DefaultsManager.shared.completedFirstRun = true
+                    DefaultsManager.shared.lastUpdated = Date()
                     
                     do {
                         try self.updateFetchedResultsController()
@@ -154,7 +155,8 @@ class RunsListViewController: UIViewController {
                 self.showToast(message: "Error fetching data: " + error.localizedDescription)
                 return
             }
-
+            
+            DefaultsManager.shared.lastUpdated = Date()
             self.tableView.reloadData()
         }
         


### PR DESCRIPTION
this is a first pass at https://github.com/AmericanWhitewater/aw-ios/issues/280.

what I've done is:

- add refresh control to the reach detail view that reloads that reach specifically
- changed the timestamp in the reach detail view to reflect `last_gauge_updated` from the API instead of the app-wide "last updated"
- add a "pull to refresh" call to action when the last gauge reading is over an hour ago

I should be very clear that I have essentially no idea what I'm doing in Swift or iOS development. So please tell me to change things if I should!